### PR TITLE
Displays generated area components as flexbox

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,11 +27,17 @@ Cypress.Commands.add('setBreakpoint', (breakpointName) => {
 })
 
 Cypress.Commands.add('haveArea', { prevSubject: true }, (subject, gridArea) => {
-  cy.wrap(subject).should('have.css', 'grid-row-start', gridArea)
-  cy.wrap(subject).should('have.css', 'grid-row-end', gridArea)
-  cy.wrap(subject).should('have.css', 'grid-column-start', gridArea)
+  const wrapper = cy.wrap(subject)
+  wrapper.should('have.css', 'grid-row-start', gridArea)
+  wrapper.should('have.css', 'grid-row-end', gridArea)
+  wrapper.should('have.css', 'grid-column-start', gridArea)
+  wrapper.should('have.css', 'grid-column-end', gridArea)
 
-  return cy.wrap(subject).should('have.css', 'grid-column-end', gridArea)
+  /**
+   * Assert area component displays as a flexbox.
+   * Safe, since all areas behaves as flexbox by default.
+   */
+  return wrapper.should('have.css', 'display', 'flex')
 })
 
 Cypress.Commands.add(

--- a/src/utils/templates/generateComponents/generateComponents.js
+++ b/src/utils/templates/generateComponents/generateComponents.js
@@ -43,6 +43,7 @@ const withPlaceholder = (
 
 const createArea = (areaName: string): TAreaComponent => styled.div`
   grid-area: ${areaName};
+  display: ${({ inline }) => (inline ? 'inline-flex' : 'flex')};
   ${(props) => applyStyles(props)};
 `
 

--- a/stories/Playground/index.jsx
+++ b/stories/Playground/index.jsx
@@ -16,12 +16,14 @@ export default class Playground extends React.Component {
   render() {
     return (
       <div>
-        <Composition
-          template={`
-          'col'
-        `}
-        >
-          {({ Col }) => ['lorem', 'ipsum'].map((entry) => <Col>{entry}</Col>)}
+        <Composition template="col" paddingVertical={20}>
+          {({ Col }) =>
+            ['lorem', 'ipsum'].map((entry, index) => (
+              <Col col="auto" key={index}>
+                {entry}
+              </Col>
+            ))
+          }
         </Composition>
 
         <Composition


### PR DESCRIPTION
# Changelog

- Sets `display` to `flex` for area components by default
- Sets `display` to `flex` when passed `inline` prop to area component

## Issues

* Closes #61 
