### PR TITLE
Only: Adds support for inclusive and notch behavior

### DIFF
--- a/cypress/integration/index.js
+++ b/cypress/integration/index.js
@@ -1,6 +1,7 @@
 require('./behavior')
 require('./only')
 require('./composition')
+require('./only')
 require('./responsive-props')
 require('./custom-configuration')
 require('./other')

--- a/cypress/integration/only/index.js
+++ b/cypress/integration/only/index.js
@@ -1,38 +1,49 @@
+const shouldRender = (selector) => () => cy.get(selector).should('be.visible')
+const shouldNotRender = (selector) => () =>
+  cy.get(selector).should('not.be.visible')
+
 describe('Only', () => {
   before(() => {
-    cy.visit('/only/example')
+    cy.visit('/only')
   })
 
-  it('Renders children at explicit breakpoint (for)', () => {
-    const shouldRender = () => cy.get('#first').should('be.visible')
-    const shouldNotRender = () => cy.get('#first').should('not.be.visible')
-
-    cy.setBreakpoint('xs').then(shouldNotRender)
-    cy.setBreakpoint('sm').then(shouldRender)
-    cy.setBreakpoint('md').then(shouldNotRender)
-    cy.setBreakpoint('lg').then(shouldNotRender)
-    cy.setBreakpoint('xl').then(shouldNotRender)
+  it('Renders children at the explicit breakpoint (for)', () => {
+    cy.setBreakpoint('xs').then(shouldNotRender('#first'))
+    cy.setBreakpoint('sm').then(shouldRender('#first'))
+    cy.setBreakpoint('md').then(shouldNotRender('#first'))
+    cy.setBreakpoint('lg').then(shouldNotRender('#first'))
+    cy.setBreakpoint('xl').then(shouldNotRender('#first'))
   })
 
-  it('Renders children to a breakpoint (to)', () => {
-    const shouldRender = () => cy.get('#second').should('be.visible')
-    const shouldNotRender = () => cy.get('#second').should('not.be.visible')
-
-    cy.setBreakpoint('xs').then(shouldRender)
-    cy.setBreakpoint('sm').then(shouldRender)
-    cy.setBreakpoint('md').then(shouldNotRender)
-    cy.setBreakpoint('lg').then(shouldNotRender)
-    cy.setBreakpoint('xl').then(shouldNotRender)
+  it('Renders children up to a given breakpoint (to)', () => {
+    cy.setBreakpoint('xs').then(shouldRender('#second'))
+    cy.setBreakpoint('sm').then(shouldRender('#second'))
+    cy.setBreakpoint('md').then(shouldNotRender('#second'))
+    cy.setBreakpoint('lg').then(shouldNotRender('#second'))
+    cy.setBreakpoint('xl').then(shouldNotRender('#second'))
   })
 
-  it('Renders children from a breakpoint (from)', () => {
-    const shouldRender = () => cy.get('#third').should('be.visible')
-    const shouldNotRender = () => cy.get('#third').should('not.be.visible')
+  it('Renders children starting from a given breakpoint (from)', () => {
+    cy.setBreakpoint('xs').then(shouldNotRender('#third'))
+    cy.setBreakpoint('sm').then(shouldNotRender('#third'))
+    cy.setBreakpoint('md').then(shouldNotRender('#third'))
+    cy.setBreakpoint('lg').then(shouldRender('#third'))
+    cy.setBreakpoint('xl').then(shouldRender('#third'))
+  })
 
-    cy.setBreakpoint('xs').then(shouldNotRender)
-    cy.setBreakpoint('sm').then(shouldNotRender)
-    cy.setBreakpoint('md').then(shouldNotRender)
-    cy.setBreakpoint('lg').then(shouldRender)
-    cy.setBreakpoint('xl').then(shouldRender)
+  it('Supports inclusive (bell) behavior', () => {
+    cy.setBreakpoint('xs').then(shouldNotRender('#fourth'))
+    cy.setBreakpoint('sm').then(shouldRender('#fourth'))
+    cy.setBreakpoint('md').then(shouldRender('#fourth'))
+    cy.setBreakpoint('lg').then(shouldNotRender('#fourth'))
+    cy.setBreakpoint('xl').then(shouldNotRender('#fourth'))
+  })
+
+  it('Supports exclusive (notch) behavior', () => {
+    cy.setBreakpoint('xs').then(shouldRender('#fifth'))
+    cy.setBreakpoint('sm').then(shouldRender('#fifth'))
+    cy.setBreakpoint('md').then(shouldNotRender('#fifth'))
+    cy.setBreakpoint('lg').then(shouldRender('#fifth'))
+    cy.setBreakpoint('xl').then(shouldRender('#fifth'))
   })
 })

--- a/cypress/integration/other/polymorphic-prop.spec.js
+++ b/cypress/integration/other/polymorphic-prop.spec.js
@@ -7,7 +7,7 @@ describe('Polymorphic prop', () => {
     cy.get('#default').haveTag('div')
   })
 
-  it('Renders a tag passed in the "as" prop', () => {
+  it('Renders polymorphic prop', () => {
     cy.get('#header').haveTag('header')
     cy.get('#main').haveTag('main')
     cy.get('#footer').haveTag('footer')

--- a/examples/only/OnlyExample.jsx
+++ b/examples/only/OnlyExample.jsx
@@ -5,17 +5,32 @@ import Square from '../../stories/Square'
 export default class OnlyExample extends React.Component {
   render() {
     return (
-      <React.Fragment>
+      <>
+        {/* Explicit */}
         <Only for="sm">
           <Square id="first">First</Square>
         </Only>
+
+        {/* High-pass */}
         <Only to="md">
           <Square id="second">Second</Square>
         </Only>
+
+        {/* Low-pass */}
         <Only from="lg">
           <Square id="third">Third</Square>
         </Only>
-      </React.Fragment>
+
+        {/* Bell */}
+        <Only from="sm" to="lg">
+          <Square id="fourth">Fourth</Square>
+        </Only>
+
+        {/* Notch */}
+        <Only except from="md" to="lg">
+          <Square id="fifth">Fifth</Square>
+        </Only>
+      </>
     )
   }
 }

--- a/examples/only/index.jsx
+++ b/examples/only/index.jsx
@@ -4,7 +4,7 @@ import OnlyExample from './OnlyExample'
 
 const Composition = ({ match }) => (
   <Switch>
-    <Route path={`${match.path}/example`} component={OnlyExample} />
+    <Route path={match.path} component={OnlyExample} />
   </Switch>
 )
 

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -79,7 +79,7 @@ const Only = ({
   }
 
   /* Low-pass, --\__ */
-  if (maxBreakpoint && !minBreakpoint) {
+  if (!minBreakpoint && maxBreakpoint) {
     return wrapWith(closeBreakpoint(maxBreakpoint))
   }
 

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -54,13 +54,13 @@ const Only = ({
   const minBreakpoint = Layout.getBreakpoint(minBreakpointName)
   const maxBreakpoint = Layout.getBreakpoint(maxBreakpointName)
 
-  /* Inclusive, __/--\__ */
+  /* Bell, __/--\__ */
   if (minBreakpoint && maxBreakpoint && !except) {
     return wrapWith(
       mergeBreakpoints(
-        { behavior: 'up', ...minBreakpoint },
         { behavior: 'down', ...maxBreakpoint },
-        true,
+        { behavior: 'up', ...minBreakpoint },
+        false,
       ),
     )
   }

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -69,7 +69,6 @@ const Only = ({
   if (minBreakpoint && maxBreakpoint && except) {
     return wrapWith(
       closeBreakpoint(minBreakpoint),
-      null,
       openBreakpoint(maxBreakpoint),
     )
   }

--- a/src/utils/templates/generateComponents/generateComponents.tsx
+++ b/src/utils/templates/generateComponents/generateComponents.tsx
@@ -7,6 +7,8 @@ import capitalize from '../../strings/capitalize'
 import getAreaBreakpoints, {
   AreaBreakpoint,
 } from '../../breakpoints/getAreaBreakpoints'
+import { Breakpoint } from '../../../const/defaultOptions'
+import { GenericProps } from '../../../const/props'
 
 export type AreaComponent = React.FunctionComponent<BoxProps>
 export interface AreasMap {
@@ -18,30 +20,26 @@ export interface AreasMap {
  * This is used for conditional components, where placeholder component is rendered
  * until the condition for the area component is met (i.e. breakpoint).
  */
-const wrapInPlaceholder = (
+export const wrapInPlaceholder = (
   Component: AreaComponent,
-  areaParams: AreaBreakpoint[],
+  areaParams: Breakpoint[],
 ) => {
-  const Placeholder: any = ({ children, ...restProps }) =>
-    areaParams
-      .filter(Boolean)
-      .reduce<Array<React.ReactElement<MediaQuery>>>(
-        (components, breakpointOptions, index) => {
-          const { behavior, ...breakpointProps } = breakpointOptions
-
-          return components.concat(
-            <MediaQuery
-              {...breakpointProps}
-              key={`${Component.displayName}_${index}`}
-            >
-              {(matches) =>
-                matches && <Component {...restProps}>{children}</Component>
-              }
-            </MediaQuery>,
-          )
-        },
-        [],
+  const Placeholder = ({
+    children,
+    ...restProps
+  }: { children: React.ReactNode } & GenericProps) =>
+    areaParams.filter(Boolean).reduce((components, breakpointProps, index) => {
+      return components.concat(
+        <MediaQuery
+          {...breakpointProps}
+          key={`${Component.displayName}_${index}`}
+        >
+          {(matches) =>
+            matches && <Component {...restProps}>{children}</Component>
+          }
+        </MediaQuery>,
       )
+    }, [])
 
   Placeholder.displayName = `Placeholder(${Component.displayName})`
 

--- a/stories/OnlyDemo.jsx
+++ b/stories/OnlyDemo.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Only } from '../lib'
+
+export default class OnlyDemo extends React.Component {
+  render() {
+    return (
+      <>
+        <Only to="md">Up to MD</Only>
+        <Only from="md">From MD and up</Only>
+        <Only for="xs">XS only</Only>
+        <Only for="sm">SM only</Only>
+        <Only for="md">MD only</Only>
+        <Only for="lg">LG only</Only>
+        <Only from="sm" to="lg">
+          From SM to LG
+        </Only>
+        <Only except from="sm" to="lg">
+          Everywhere except SM and LG
+        </Only>
+      </>
+    )
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -5,8 +5,10 @@ import './styles.css'
 import Playground from './Playground'
 import Demo from './Demo'
 import PeriodExample from './PeriodExample'
+import OnlyDemo from './OnlyDemo'
 
 storiesOf('Stories', module)
   .add('Playground', () => <Playground />)
   .add('Demo', () => <Demo />)
   .add('Period', () => <PeriodExample />)
+  .add('OnlyDemo', () => <OnlyDemo />)


### PR DESCRIPTION
- Closes #74 

# Change log:

- Provides stable API for inclusive and notch behaviors of Only children
- Reuses the responsive wrapping logic from `generateComponents()`
- Covers Only components with integration tests