### PR TITLE
Replace "btoa" call with "hasString" util

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run:
           name: Checking bundle size
-          command: node_modules/.bin/bundlesize
+          command: yarn run bundlesize
 
       - run:
           name: Unit tests

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "cypress:cli": "node_modules/.bin/cypress run --spec cypress/integration/index.js --browser chrome",
     "test:e2e": "server-test examples http-get://localhost:9987 cypress:cli",
     "test": "yarn run test:unit && yarn run test:e2e",
+    "bundlesize": "node_modules/.bin/bundlesize",
     "precommit": "lint-staged",
-    "prepush": "yarn run test:unit",
-    "preversion": "yarn run build && yarn test"
+    "prepush": "yarn run bundlesize && yarn run test:unit",
+    "preversion": "yarn run build && yarn run bundlesize && yarn test"
   },
   "lint-staged": {
     ".{js,jsx}": [

--- a/src/utils/strings/hashString/hasString.spec.ts
+++ b/src/utils/strings/hashString/hasString.spec.ts
@@ -1,0 +1,9 @@
+import hashString from './hashString'
+
+test('Returns numeric hash based on the given string', () => {
+  const str = 'template:header,content,footer'
+  expect(hashString(str)).toEqual('1927731245')
+  expect(hashString(str)).toEqual('1927731245')
+
+  expect(hashString('templateMd:header,content,footer')).toEqual('1323128868')
+})

--- a/src/utils/strings/hashString/hasString.spec.ts
+++ b/src/utils/strings/hashString/hasString.spec.ts
@@ -2,8 +2,12 @@ import hashString from './hashString'
 
 test('Returns numeric hash based on the given string', () => {
   const str = 'template:header,content,footer'
-  expect(hashString(str)).toEqual('1927731245')
-  expect(hashString(str)).toEqual('1927731245')
+  expect(hashString(str)).toEqual(1927731245)
+  expect(hashString(str)).toEqual(1927731245)
 
-  expect(hashString('templateMd:header,content,footer')).toEqual('1323128868')
+  expect(hashString('templateMd:header,content,footer')).toEqual(1323128868)
+})
+
+test('Returns zero for an empty string', () => {
+  expect(hashString('')).toEqual(0)
 })

--- a/src/utils/strings/hashString/hashString.ts
+++ b/src/utils/strings/hashString/hashString.ts
@@ -1,0 +1,13 @@
+export default function hashString(str: string): string {
+  const { length } = str
+  let hash = 0
+  let i = 0
+
+  if (length > 0) {
+    while (i < length) {
+      hash = ((hash << 5) - hash + str.charCodeAt(i++)) | 0
+    }
+  }
+
+  return hash.toString()
+}

--- a/src/utils/strings/hashString/hashString.ts
+++ b/src/utils/strings/hashString/hashString.ts
@@ -1,4 +1,4 @@
-export default function hashString(str: string): string {
+export default function hashString(str: string): number {
   const { length } = str
   let hash = 0
   let i = 0
@@ -9,5 +9,5 @@ export default function hashString(str: string): string {
     }
   }
 
-  return hash.toString()
+  return hash
 }

--- a/src/utils/strings/hashString/index.ts
+++ b/src/utils/strings/hashString/index.ts
@@ -1,0 +1,2 @@
+export { default } from './hashString'
+export * from './hashString'

--- a/src/utils/templates/parseTemplates/parseTemplates.ts
+++ b/src/utils/templates/parseTemplates/parseTemplates.ts
@@ -11,7 +11,7 @@ type ParseTemplates = (props: Props) => AreasMap
 /**
  * Memoize areas generation based on the sanitized "templateProp:areas" pairs.
  * Alphabetical sorting of incoming template areas allows reproducible cache keys.
- * @todo `paris` is an empty array sometimes. Should we handle it somehow?
+ * @todo `pairs` is an empty array sometimes. Should we handle it somehow?
  */
 const memoized = memoizeWith((templateProps: TemplateProps) => {
   const pairs = Object.entries(templateProps).reduce<string[]>(
@@ -21,7 +21,7 @@ const memoized = memoizeWith((templateProps: TemplateProps) => {
     [],
   )
 
-  return hashString(pairs.join())
+  return hashString(pairs.join()).toString()
 })
 
 const parseTemplates: ParseTemplates = compose(

--- a/src/utils/templates/parseTemplates/parseTemplates.ts
+++ b/src/utils/templates/parseTemplates/parseTemplates.ts
@@ -1,6 +1,7 @@
 import compose from '../../functions/compose'
 import memoizeWith from '../../functions/memoizeWith'
 import getAreasList from '../getAreasList'
+import hashString from '../../strings/hashString'
 import { Props } from '../../strings/parsePropName'
 import generateComponents, { AreasMap } from '../generateComponents'
 import filterTemplateProps, { TemplateProps } from './filterTemplateProps'
@@ -8,18 +9,19 @@ import filterTemplateProps, { TemplateProps } from './filterTemplateProps'
 type ParseTemplates = (props: Props) => AreasMap
 
 /**
- * Memoize components generation based on the sanitized "templateProp:areas" pairs.
- * Alphabetical sorting of template areas allows reproducible cache keys.
+ * Memoize areas generation based on the sanitized "templateProp:areas" pairs.
+ * Alphabetical sorting of incoming template areas allows reproducible cache keys.
+ * @todo `paris` is an empty array sometimes. Should we handle it somehow?
  */
 const memoized = memoizeWith((templateProps: TemplateProps) => {
   const pairs = Object.entries(templateProps).reduce<string[]>(
-    (acc, [templateName, templateAreas]) => {
-      return acc.concat(`${templateName}:${templateAreas.join()}`)
+    (acc, [propName, templateAreas]) => {
+      return acc.concat(`${propName}:${templateAreas.join()}`)
     },
     [],
   )
 
-  return btoa(pairs.join())
+  return hashString(pairs.join())
 })
 
 const parseTemplates: ParseTemplates = compose(

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "no-console": false,
     "prefer-template": [true, "always"],
+    "no-bitwise": false,
 
     "ordered-imports": [false, "never"],
     "object-literal-sort-keys": [false, "never"],


### PR DESCRIPTION
Replaces the call to the browser `btoa`, which doesn't exist on server-side, to prevent it from breaking app's SSR logic.

- Fixes #101 
