### PR TITLE
Adds unit test for SSR

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'Atomic layout',
   verbose: true,
-  roots: ['src'],
+  roots: ['tests', 'src'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   transform: {

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -51,7 +51,7 @@ const Only = ({
   from: minBreakpointName,
   to: maxBreakpointName,
   ...restProps
-}: { children: React.ReactNode } & OnlyProps): React.ReactNode => {
+}: { children: any } & OnlyProps): JSX.Element => {
   const wrapWith = createWrapper(children, restProps)
 
   /* Render on explicit breakpoint */

--- a/tests/ssr.spec.tsx
+++ b/tests/ssr.spec.tsx
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+import { Box, Only, Composition } from '../lib'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+test('Renders server-side without crashing', () => {
+  const renderOnServer = () =>
+    renderToString(
+      <main>
+        <Box padding={10} />
+        <Only for="md">Responsive content</Only>
+        <Composition template="first second">
+          {({ First, Second }) => (
+            <>
+              <First>First</First>
+              <Second>Second</Second>
+            </>
+          )}
+        </Composition>
+      </main>,
+    )
+
+  expect(renderOnServer).not.toThrow()
+})

--- a/tests/ssr.spec.tsx
+++ b/tests/ssr.spec.tsx
@@ -1,9 +1,9 @@
 /**
  * @jest-environment node
  */
-import { Box, Only, Composition } from '../lib'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
+import { Box, Only, Composition } from '../src'
 
 test('Renders server-side without crashing', () => {
   const renderOnServer = () =>


### PR DESCRIPTION
* Adds a simple unit test to assert that server-side rendering doesn't throw an exception when rendering components from `atomic-layout` package.

- Partially covers #72 
