### PR TITLE
transformNumeric: Handle "0" as the explicit value

### DIFF
--- a/cypress/integration/other/prop-aliases.spec.js
+++ b/cypress/integration/other/prop-aliases.spec.js
@@ -1,5 +1,6 @@
 import propAliases from '../../../src/const/propAliases'
 
+const defaultValue = 10
 const assertValues = {
   // prettier-ignore
   template: "first",
@@ -9,7 +10,7 @@ const assertValues = {
   colStart: '2',
   colEnd: '3',
   gutter: '20px 25px',
-  margin: 0,
+  margin: ['0px', 10],
   row: '1 / auto',
   rowStart: '2',
   rowEnd: '3',
@@ -33,19 +34,21 @@ const exactAssertion = {
 }
 
 describe('Prop aliases', () => {
-  Object.keys(propAliases).forEach((aliasPropName) => {
-    it(aliasPropName, () => {
-      const propValue = assertValues[aliasPropName] || 10
+  Object.keys(propAliases).forEach((propAliasName) => {
+    it(propAliasName, () => {
+      const propValues = assertValues[propAliasName] || defaultValue
 
-      cy.visit(
-        `/other/prop-aliases?propAlias=${aliasPropName}&propValue=${propValue}`,
-      )
+      Array.prototype.concat(propValues).forEach((propValue) => {
+        cy.visit(
+          `/other/prop-aliases?propAlias=${propAliasName}&propValue=${propValue}`,
+        )
 
-      cy.get('#composition').assertPropAlias(
-        aliasPropName,
-        propValue,
-        exactAssertion[aliasPropName],
-      )
+        cy.get('#composition').assertPropAlias(
+          propAliasName,
+          propValue,
+          exactAssertion[propAliasName],
+        )
+      })
     })
   })
 })

--- a/cypress/integration/other/prop-aliases.spec.js
+++ b/cypress/integration/other/prop-aliases.spec.js
@@ -9,6 +9,7 @@ const assertValues = {
   colStart: '2',
   colEnd: '3',
   gutter: '20px 25px',
+  margin: 0,
   row: '1 / auto',
   rowStart: '2',
   rowEnd: '3',

--- a/src/utils/functions/isset/index.ts
+++ b/src/utils/functions/isset/index.ts
@@ -1,0 +1,2 @@
+export { default } from './isset'
+export * from './isset'

--- a/src/utils/functions/isset/isset.spec.ts
+++ b/src/utils/functions/isset/isset.spec.ts
@@ -1,0 +1,15 @@
+import isset from './isset'
+
+test('Returns "true" when a variable is set', () => {
+  expect(isset(0)).toBe(true)
+  expect(isset('')).toBe(true)
+  expect(isset('a')).toBe(true)
+  expect(isset([])).toBe(true)
+  expect(isset({})).toBe(true)
+  expect(isset(function() {})).toBe(true)
+})
+
+test('Returns "false" when a variable is not set', () => {
+  expect(isset(null)).toBe(false)
+  expect(isset(undefined)).toBe(false)
+})

--- a/src/utils/functions/isset/isset.ts
+++ b/src/utils/functions/isset/isset.ts
@@ -1,0 +1,3 @@
+export default function isset(variable: any): boolean {
+  return typeof variable !== 'undefined' && variable !== null
+}

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -4,7 +4,7 @@ test('Suffixes numeric values with "px" string', () => {
   expect(transformNumeric(5)).toEqual('5px')
 })
 
-test('Returns string values as it is', () => {
+test('Returns string values as is', () => {
   expect(transformNumeric('2vh')).toEqual('2vh')
 })
 

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -4,7 +4,7 @@ test('Suffixes numeric values with "px" string', () => {
   expect(transformNumeric(5)).toEqual('5px')
 })
 
-test('Returns string values as is', () => {
+test('Returns string values as it is', () => {
   expect(transformNumeric('2vh')).toEqual('2vh')
 })
 
@@ -12,12 +12,7 @@ test('Returns empty string for empty string as value', () => {
   expect(transformNumeric('')).toEqual('')
 })
 
-test('Handles explicit 0 as a value', () => {
+test('Handles explicit 0 as a value and no suffix is attached', () => {
   expect(transformNumeric('0')).toEqual('0')
-  expect(transformNumeric(0)).toEqual('0px')
-})
-
-test('Outputs CSS for 0 as a value', () => {
-  expect(transformNumeric('0')).toEqual('0')
-  expect(transformNumeric(0)).toEqual('0px')
+  expect(transformNumeric(0)).toEqual('0')
 })

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -8,8 +8,13 @@ test('Returns string values as is', () => {
   expect(transformNumeric('2vh')).toEqual('2vh')
 })
 
-test('Returns "undefined" when no value is given', () => {
-  expect(transformNumeric()).toEqual('')
+test('Returns empty string for empty string as value', () => {
+  expect(transformNumeric('')).toEqual('')
+})
+
+test('Handles explicit 0 as a value', () => {
+  expect(transformNumeric('0')).toEqual('0')
+  expect(transformNumeric(0)).toEqual('0px')
 })
 
 test('Outputs CSS for 0 as a value', () => {

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -12,6 +12,7 @@ test('Returns "undefined" when no value is given', () => {
   expect(transformNumeric()).toEqual('')
 })
 
-test('Suffixes numeric values with "px" string, if value is zero the result should be 0px', () => {
+test('Outputs CSS for 0 as a value', () => {
+  expect(transformNumeric('0')).toEqual('0')
   expect(transformNumeric(0)).toEqual('0px')
 })

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -1,6 +1,6 @@
 import transformNumeric from './transformNumeric'
 
-test('Suffixes numeric values with "rem" string', () => {
+test('Suffixes numeric values with "px" string', () => {
   expect(transformNumeric(5)).toEqual('5px')
 })
 
@@ -10,4 +10,8 @@ test('Returns string values as is', () => {
 
 test('Returns "undefined" when no value is given', () => {
   expect(transformNumeric()).toEqual('')
+})
+
+test('Suffixes numeric values with "px" string, if value is zero the result should be 0px', () => {
+  expect(transformNumeric(0)).toEqual('0px')
 })

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -10,9 +10,6 @@ export default function transformNumeric(value?: number | string): string {
    * Suffix numeric value with the default unit.
    * Accept explicit (string) value as-is.
    *
-   * @todo MAKE SURE RETURNING AN EMPTY STRING RESULTS INTO
-   * PROPER CSS PROPERTIES SET IN THE GENERATED STYLES.
-   *
    * When given value is zero then its generated as it is, no suffix is attached
    */
   const suffix =

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -1,7 +1,7 @@
 import Layout from '../../Layout'
 
 export default function transformNumeric(value?: number | string): string {
-  if (!value) {
+  if (typeof value === 'undefined' || value === null) {
     return ''
   }
 

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -1,7 +1,8 @@
 import Layout from '../../Layout'
+import isset from '../functions/isset'
 
 export default function transformNumeric(value?: number | string): string {
-  if (typeof value === 'undefined' || value === null) {
+  if (!isset(value)) {
     return ''
   }
 

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -12,8 +12,11 @@ export default function transformNumeric(value?: number | string): string {
    *
    * @todo MAKE SURE RETURNING AN EMPTY STRING RESULTS INTO
    * PROPER CSS PROPERTIES SET IN THE GENERATED STYLES.
+   *
+   * When given value is zero then its generated as it is, no suffix is attached
    */
-  const suffix = typeof value === 'number' ? Layout.options.defaultUnit : ''
+  const suffix =
+    typeof value === 'number' && value !== 0 ? Layout.options.defaultUnit : ''
 
   return `${value}${suffix}`
 }

--- a/src/utils/styles/applyStyles/applyStyles.ts
+++ b/src/utils/styles/applyStyles/applyStyles.ts
@@ -2,6 +2,7 @@ import { BreakpointBehavior } from '../../../const/defaultOptions'
 import propAliases from '../../../const/propAliases'
 import Layout from '../../../Layout'
 import parsePropName, { Props } from '../../strings/parsePropName'
+import isset from '../../functions/isset'
 import createMediaQuery from '../createMediaQuery'
 
 const createStyleString = (
@@ -37,7 +38,7 @@ export default function applyStyles(pristineProps: Props): string {
       /* Filter out props that are not included in prop aliases */
       .filter(({ purePropName }) => propAliases.hasOwnProperty(purePropName))
       /* Filter out props with "undefined" or "null" as value */
-      .filter(({ originPropName }) => !!pristineProps[originPropName])
+      .filter(({ originPropName }) => isset(pristineProps[originPropName]))
       /* Map each prop to a CSS string */
       .map(({ purePropName, originPropName, breakpoint, behavior }) => {
         const { props, transformValue } = propAliases[purePropName]

--- a/stories/Demo.jsx
+++ b/stories/Demo.jsx
@@ -29,7 +29,8 @@ const templateTv = `
 const Demo = () => (
   <div>
     <Composition
-      gutter={16}
+      gutter={0} // this is not getting generated
+      margin={10} // this is getting generated 
       template={templateMobile}
       templateSm={templateTablet}
       templateMd={templateDesktop}

--- a/stories/Demo.jsx
+++ b/stories/Demo.jsx
@@ -29,8 +29,8 @@ const templateTv = `
 const Demo = () => (
   <div>
     <Composition
-      gutter={0} // this is not getting generated
-      margin={10} // this is getting generated 
+      gutter={10}
+      margin={10}
       template={templateMobile}
       templateSm={templateTablet}
       templateMd={templateDesktop}

--- a/stories/Demo.jsx
+++ b/stories/Demo.jsx
@@ -30,7 +30,7 @@ const Demo = () => (
   <div>
     <Composition
       gutter={10}
-      margin={10}
+      margin={0}
       template={templateMobile}
       templateSm={templateTablet}
       templateMd={templateDesktop}


### PR DESCRIPTION
## Change log
- Fixes #100 
- [x] `transformNumeric` now asserts if the `value` is set, not if it's truthy
- [x] Fix a typo in existing `transformNumeric` unit test
- [x] Add unit tests to cover the handling of "0" as a numeric value
- [x] Add integration test for `margin: 0` scenario