### PR TITLE
Handles "0" as a numeric value

### DIFF
--- a/src/utils/functions/isset/index.ts
+++ b/src/utils/functions/isset/index.ts
@@ -1,0 +1,2 @@
+export { default } from './isset'
+export * from './isset'

--- a/src/utils/functions/isset/isset.spec.ts
+++ b/src/utils/functions/isset/isset.spec.ts
@@ -1,0 +1,15 @@
+import isset from './isset'
+
+test('Returns "true" when a variable is set', () => {
+  expect(isset(0)).toBe(true)
+  expect(isset('')).toBe(true)
+  expect(isset('a')).toBe(true)
+  expect(isset([])).toBe(true)
+  expect(isset({})).toBe(true)
+  expect(isset(function() {})).toBe(true)
+})
+
+test('Returns "false" when a variable is not set', () => {
+  expect(isset(null)).toBe(false)
+  expect(isset(undefined)).toBe(false)
+})

--- a/src/utils/functions/isset/isset.ts
+++ b/src/utils/functions/isset/isset.ts
@@ -1,0 +1,3 @@
+export default function isset(variable: any): boolean {
+  return typeof variable !== 'undefined' && variable !== null
+}

--- a/src/utils/math/transformNumeric.spec.ts
+++ b/src/utils/math/transformNumeric.spec.ts
@@ -8,6 +8,11 @@ test('Returns string values as is', () => {
   expect(transformNumeric('2vh')).toEqual('2vh')
 })
 
-test('Returns "undefined" when no value is given', () => {
-  expect(transformNumeric()).toEqual('')
+test('Returns empty string for empty string as value', () => {
+  expect(transformNumeric('')).toEqual('')
+})
+
+test('Handles explicit 0 as a value', () => {
+  expect(transformNumeric('0')).toEqual('0')
+  expect(transformNumeric(0)).toEqual('0px')
 })

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -1,7 +1,8 @@
 import Layout from '../../Layout'
+import isset from '../functions/isset'
 
 export default function transformNumeric(value?: number | string): string {
-  if (!value) {
+  if (!isset(value)) {
     return ''
   }
 

--- a/src/utils/styles/applyStyles/applyStyles.ts
+++ b/src/utils/styles/applyStyles/applyStyles.ts
@@ -2,6 +2,7 @@ import { BreakpointBehavior } from '../../../const/defaultOptions'
 import propAliases from '../../../const/propAliases'
 import Layout from '../../../Layout'
 import parsePropName, { Props } from '../../strings/parsePropName'
+import isset from '../../functions/isset'
 import createMediaQuery from '../createMediaQuery'
 
 const createStyleString = (
@@ -37,7 +38,7 @@ export default function applyStyles(pristineProps: Props): string {
       /* Filter out props that are not included in prop aliases */
       .filter(({ purePropName }) => propAliases.hasOwnProperty(purePropName))
       /* Filter out props with "undefined" or "null" as value */
-      .filter(({ originPropName }) => !!pristineProps[originPropName])
+      .filter(({ originPropName }) => isset(pristineProps[originPropName]))
       /* Map each prop to a CSS string */
       .map(({ purePropName, originPropName, breakpoint, behavior }) => {
         const { props, transformValue } = propAliases[purePropName]

--- a/stories/Demo.jsx
+++ b/stories/Demo.jsx
@@ -29,7 +29,8 @@ const templateTv = `
 const Demo = () => (
   <div>
     <Composition
-      gutter={16}
+      gutter={10}
+      margin={10}
       template={templateMobile}
       templateSm={templateTablet}
       templateMd={templateDesktop}


### PR DESCRIPTION
- Fixes #100 

- [ ] Add integration test for `margin: 0`
- [ ] Fix unit tests, as they fail to execute due to Jest warning:

```
ts-jest[versions] (WARN) Version 24.0.0-alpha.9 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=22.0.0 <24.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS src/utils/strings/parsePropName/parsePropName.spec.ts
```
