### PR TITLE
Introduces pluggable styling API

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "cypress": "^3.0.3",
     "husky": "^2.2.0",
     "jest": "^24.8.0",
+    "emotion": "^10.0.9",
     "jest-dom": "^3.1.2",
     "lint-staged": "^8.1.0",
     "match-media-mock": "^0.1.1",

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -12,6 +12,7 @@ class Layout {
   public defaultBehavior: BreakpointBehavior = defaultOptions.defaultBehavior
   public breakpoints: Breakpoints = defaultOptions.breakpoints
   public defaultBreakpointName: string = defaultOptions.defaultBreakpointName
+  public produceStyles = defaultOptions.produceStyles
   protected isConfigureCalled: boolean = false
 
   constructor(options?: Partial<LayoutOptions>) {
@@ -38,6 +39,12 @@ class Layout {
     Object.keys(options || {}).forEach((optionName) => {
       this[optionName] = options[optionName]
     })
+
+    invariant(
+      this.produceStyles && typeof this.produceStyles === 'function',
+      'Failed to configure Layout: expected "produceStyles" to be a style producing function, but got: %s',
+      typeof this.produceStyles,
+    )
 
     invariant(
       this.breakpoints,

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import Layout from '../Layout'
 import { GenericProps } from '@const/props'
 import applyStyles from '@utils/styles/applyStyles'
 
@@ -9,7 +9,9 @@ export interface BoxProps extends GenericProps {
   inline?: boolean
 }
 
-const Box: React.FunctionComponent<BoxProps> = styled.div<BoxProps>`
+const Box: React.FunctionComponent<BoxProps> = Layout.options.produceStyles.div<
+  BoxProps
+>`
   && {
     ${applyStyles};
     display: ${({ flex, inline }) =>

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import Layout from '../Layout'
 import { GenericProps, GridProps } from '@const/props'
 import { AreasMap } from '@utils/templates/generateComponents'
 import parseTemplates from '@utils/templates/parseTemplates'
@@ -14,7 +14,7 @@ interface CompositionProps extends GenericProps, GridProps {
   inline?: boolean
 }
 
-const CompositionWrapper = styled.div<CompositionProps>`
+const CompositionWrapper = Layout.options.produceStyles.div<CompositionProps>`
   && {
     ${applyStyles};
     display: ${({ inline }) => (inline ? 'inline-grid' : 'grid')};

--- a/src/const/defaultOptions.ts
+++ b/src/const/defaultOptions.ts
@@ -16,7 +16,16 @@ export type BreakpointBehavior = 'up' | 'down' | 'only'
 export interface Breakpoints {
   [breakpointName: string]: Breakpoint
 }
+
 export interface LayoutOptions {
+  /**
+   * A function that produces tag-based styles (i.e. `produceStyles.div`)
+   * of the CSS-in-JS solution of your choice.
+   * @example
+   * import styled from 'styled-components'
+   * produceStyles: styled
+   */
+  produceStyles: any /** @todo Type this */
   /**
    * Measurement unit that suffixes numeric prop values.
    * @default "px"
@@ -27,6 +36,8 @@ export interface LayoutOptions {
   defaultUnit: MeasurementUnit
   /**
    * Map of layout breakpoints.
+   * @default Bootstrap4
+   * @see https://getbootstrap.com/docs/4.0/layout/grid/#grid-options
    */
   breakpoints: Breakpoints
   /**
@@ -35,6 +46,10 @@ export interface LayoutOptions {
    * @default "xs"
    */
   defaultBreakpointName: string
+  /**
+   * Default behavior of responsive props application.
+   * @default "up" (mobile-first)
+   */
   defaultBehavior: BreakpointBehavior
 }
 
@@ -58,7 +73,16 @@ export interface Breakpoint extends MediaQuery {
   [propName: string]: any
 }
 
+import styled from 'styled-components'
+
 const defaultOptions: LayoutOptions = {
+  /**
+   * @todo Do not import "styled-component"
+   * That makes it a dependency of "atomic-layout".
+   * Find a way to ship default behavior without requiring
+   * to have a potentially opt-out module as a dependency.
+   */
+  produceStyles: styled,
   defaultUnit: 'px',
   defaultBehavior: 'up',
   defaultBreakpointName: 'xs',

--- a/src/utils/templates/generateComponents/generateComponents.tsx
+++ b/src/utils/templates/generateComponents/generateComponents.tsx
@@ -1,14 +1,11 @@
 import { AreasList } from '../getAreasList'
 import * as React from 'react'
-import styled from 'styled-components'
 import { Breakpoint } from '@const/defaultOptions'
 import { GenericProps } from '@const/props'
 import MediaQuery from '@components/MediaQuery'
 import Box, { BoxProps } from '@components/Box'
 import capitalize from '@utils/strings/capitalize'
-import getAreaBreakpoints, {
-  AreaBreakpoint,
-} from '@utils/breakpoints/getAreaBreakpoints'
+import getAreaBreakpoints from '@utils/breakpoints/getAreaBreakpoints'
 
 export type AreaComponent = React.FunctionComponent<BoxProps>
 export interface AreasMap {


### PR DESCRIPTION
Introduces pluggable styling API to use Atomic layout with any tag-based CSS-in-JS solution (styled-components, emotion). Provides any related adjustments to the library to be used style-agnostic.

## GitHub

- Closes #57 

## Specification

1. Atomic layout uses a designated required `produceStyles` function that generated styled components (similar to `styled` from `styled-components`).
1. When not provided the `produceStyles` option, Atomic layout prints an error asking to provide it. The error message includes an example of API usage with `styled-components`.
1. You should provide `produceStyles`, as there is no default behavior on purpose. This is to make Atomic layout usable with any component-based CSS-in-JS solution without listing any of them as the library's dependency.
1. To provide a style producer function pass it as a value of `produceStyles` property:

```js
import emotion from '@emotion/styled'
import Layout from 'atomic-layout'

Layout.configure({
  produceStyles: emotion,
})
```

4. Style producer can be specified only once, just as the rest of layout options via `Layout` API.

## Release

Prior to version `1.0` the library's API should be treated as experimental, meaning that it may introduce breaking changes in minor versions. Although it's not a proper semantic release process, I see no reason to establish a stable API only somewhere around version `12.x`. 

## Roadmap

- [ ] Provide parametric integration tests to assert the same test suits but using `emotion` as the style producer
- [ ] Ensure proper references and evaluation of custom styles producer