### PR TITLE
Ensures style overrides for polymorphic usage

### DIFF
--- a/cypress/integration/other/polymorphic-prop.spec.js
+++ b/cypress/integration/other/polymorphic-prop.spec.js
@@ -8,8 +8,27 @@ describe('Polymorphic prop', () => {
   })
 
   it('Renders polymorphic prop', () => {
-    cy.get('#header').haveTag('header')
     cy.get('#main').haveTag('main')
     cy.get('#footer').haveTag('footer')
+  })
+
+  describe('When using custom React component', () => {
+    it('renders custom React component', () => {
+      cy.get('#header').haveTag('header')
+    })
+
+    it('preserves irrelevant styles', () => {
+      cy.get('#header').should(
+        'have.css',
+        'background-color',
+        'rgb(238, 238, 238)',
+      )
+    })
+
+    it('overrides layout styles', () => {
+      cy.get('#header')
+        .should('have.css', 'display', 'flex')
+        .should('have.css', 'padding', '20px')
+    })
   })
 })

--- a/examples/Core/Rendering/PolymorphicProp.jsx
+++ b/examples/Core/Rendering/PolymorphicProp.jsx
@@ -1,12 +1,19 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Composition } from 'atomic-layout'
 import Square from '@stories/Square'
+
+const CustomHeader = styled.header`
+  background-color: #eee;
+  display: block;
+  padding: 10px;
+`
 
 const PolymorphicProp = () => (
   <Composition areas="header main element footer" gutter={10}>
     {({ Header, Main, Element, Footer }) => (
       <React.Fragment>
-        <Header as="header" id="header">
+        <Header flex as={CustomHeader} id="header" padding={20}>
           <Square>Header</Square>
         </Header>
         <Main as="main" id="main">

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -10,15 +10,17 @@ export interface BoxProps extends GenericProps {
 }
 
 const Box: React.FunctionComponent<BoxProps> = styled.div<BoxProps>`
-  ${applyStyles};
-  display: ${({ flex, inline }) =>
-    flex
-      ? inline
-        ? 'inline-flex'
-        : 'flex'
-      : inline
-      ? 'inline-block'
-      : 'block'};
+  && {
+    ${applyStyles};
+    display: ${({ flex, inline }) =>
+      flex
+        ? inline
+          ? 'inline-flex'
+          : 'flex'
+        : inline
+        ? 'inline-block'
+        : 'block'};
+  }
 `
 
 export default Box

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -15,8 +15,10 @@ interface CompositionProps extends GenericProps, GridProps {
 }
 
 const CompositionWrapper = styled.div<CompositionProps>`
-  ${applyStyles};
-  display: ${({ inline }) => (inline ? 'inline-grid' : 'grid')};
+  && {
+    ${applyStyles};
+    display: ${({ inline }) => (inline ? 'inline-grid' : 'grid')};
+  }
 `
 
 const Composition: React.FunctionComponent<CompositionProps> = ({


### PR DESCRIPTION
# Change log

- Sets layout-related styles generated by the library's component primitives as the highest priority
- Adds integration tests to ensure proper styles specificity when using polymorphic prop API from `styled-components`

# GitHub

- Closes #150 
