### PR TITLE
Adds "gap" prop alias

### DIFF
--- a/src/const/propAliases.spec.tsx
+++ b/src/const/propAliases.spec.tsx
@@ -16,6 +16,7 @@ const explicitValues = {
   col: '1 / auto',
   colStart: '2',
   colEnd: '3',
+  gap: '20px 25px',
   gutter: '20px 25px',
   margin: ['0px', 10],
   flexDirection: ['row', 'column'],

--- a/src/const/propAliases.ts
+++ b/src/const/propAliases.ts
@@ -65,6 +65,18 @@ const propAliases: PropAliases = {
   rowEnd: {
     props: ['grid-row-end'],
   },
+  gap: {
+    props: ['grid-gap'],
+    transformValue: transformNumeric,
+  },
+  gapCol: {
+    props: ['grid-column-gap'],
+    transformValue: transformNumeric,
+  },
+  gapRow: {
+    props: ['grid-row-gap'],
+    transformValue: transformNumeric,
+  },
   gutter: {
     props: ['grid-gap'],
     transformValue: transformNumeric,
@@ -86,7 +98,7 @@ const propAliases: PropAliases = {
     transformValue: transformNumeric,
   },
   autoFlow: {
-    props: ['grid-auto-flow']
+    props: ['grid-auto-flow'],
   },
   align: {
     props: ['align-self'],

--- a/src/const/props.ts
+++ b/src/const/props.ts
@@ -262,6 +262,24 @@ export interface GridProps extends GenericProps {
    * @css `grid-gap`
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-gap
    */
+  gap?: Numeric
+  /**
+   * Spacing between the grid columns.
+   * @css `grid-column-gap`
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-gap
+   */
+  gapCol?: Numeric
+  /**
+   * Spacing between the grid rows.
+   * @css `grid-row-gap`
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row-gap
+   */
+  gapRow?: Numeric
+  /**
+   * Spacing between rows and columns.
+   * @css `grid-gap`
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/grid-gap
+   */
   gutter?: Numeric
   /**
    * Spacing between the grid columns.

--- a/src/utils/breakpoints/getAreaBreakpoints/behaviorUp.spec.ts
+++ b/src/utils/breakpoints/getAreaBreakpoints/behaviorUp.spec.ts
@@ -28,7 +28,7 @@ describe('when handling "up" behavior', () => {
     ])
   })
 
-  it('always render area with min/max resolution', () => {
+  it('always renders area with min/max resolution', () => {
     expect(
       getAreaBreakpoints('first', [
         {


### PR DESCRIPTION
# Change log

- Adds `gap`, `gapCol`, `gapRow` prop alias for `grid-gap`, `grid-column-gap` and `grid-row-gap` correspondingly
