### PR TITLE
Layout: Stores options on the rool level of a class

### DIFF
--- a/src/Layout.spec.ts
+++ b/src/Layout.spec.ts
@@ -14,7 +14,16 @@ describe('Layout', () => {
   })
 
   it('instantiated with default options', () => {
-    expect(Layout).toHaveProperty('options', defaultOptions)
+    expect(Layout).toHaveProperty('defaultUnit', defaultOptions.defaultUnit)
+    expect(Layout).toHaveProperty(
+      'defaultBehavior',
+      defaultOptions.defaultBehavior,
+    )
+    expect(Layout).toHaveProperty(
+      'defaultBreakpointName',
+      defaultOptions.defaultBreakpointName,
+    )
+    expect(Layout).toHaveProperty('breakpoints', defaultOptions.breakpoints)
   })
 
   describe('exports public API', () => {

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -1,14 +1,20 @@
 import defaultOptions, {
   LayoutOptions,
   Breakpoint,
+  Breakpoints,
+  MeasurementUnit,
+  BreakpointBehavior,
 } from './const/defaultOptions'
 import invariant from './utils/invariant'
 
 class Layout {
-  public options: LayoutOptions = defaultOptions
+  public defaultUnit: MeasurementUnit = defaultOptions.defaultUnit
+  public defaultBehavior: BreakpointBehavior = defaultOptions.defaultBehavior
+  public breakpoints: Breakpoints = defaultOptions.breakpoints
+  public defaultBreakpointName: string = defaultOptions.defaultBreakpointName
   protected isConfigureCalled: boolean = false
 
-  constructor(options: Partial<LayoutOptions>) {
+  constructor(options?: Partial<LayoutOptions>) {
     return this.configure(options, false)
   }
 
@@ -16,6 +22,8 @@ class Layout {
    * Applies global layout options.
    */
   public configure(options: Partial<LayoutOptions>, warnOnMultiple = true) {
+    console.log({ options })
+
     if (warnOnMultiple) {
       invariant(
         !this.isConfigureCalled,
@@ -29,34 +37,31 @@ class Layout {
       options,
     )
 
-    this.options = {
-      ...defaultOptions,
-      ...options,
-    }
-
-    const { breakpoints, defaultBreakpointName } = this.options
+    Object.keys(options || {}).forEach((optionName) => {
+      this[optionName] = options[optionName]
+    })
 
     invariant(
-      breakpoints,
+      this.breakpoints,
       'Failed to configure Layout: expected to have at least one breakpoint specified, but got none.',
     )
 
     invariant(
-      breakpoints.hasOwnProperty(defaultBreakpointName),
+      this.breakpoints.hasOwnProperty(this.defaultBreakpointName),
       'Failed to configure Layout: cannot use "%s" as the default breakpoint (breakpoint not found).',
-      defaultBreakpointName,
+      this.defaultBreakpointName,
     )
 
     invariant(
-      defaultBreakpointName,
+      this.defaultBreakpointName,
       'Failed to configure Layout: expected "defaultBreakpointName" property set, but got: %s.',
-      defaultBreakpointName,
+      this.defaultBreakpointName,
     )
 
     invariant(
-      typeof defaultBreakpointName === 'string',
+      typeof this.defaultBreakpointName === 'string',
       'Failed to configure Layout: expected "defaultBreakpointName" to be a string, but got: %s',
-      typeof defaultBreakpointName,
+      typeof this.defaultBreakpointName,
     )
 
     /* Mark configure method as called to prevent its multiple calls */
@@ -70,15 +75,15 @@ class Layout {
    * in the current layout configuration.
    */
   public getBreakpointNames(): string[] {
-    return Object.keys(this.options.breakpoints)
+    return Object.keys(this.breakpoints)
   }
 
   /**
    * Returns breakpoint options by the given breakpoint name.
    */
   public getBreakpoint(breakpointName: string): Breakpoint | undefined {
-    return this.options.breakpoints[breakpointName]
+    return this.breakpoints[breakpointName]
   }
 }
 
-export default new Layout(defaultOptions)
+export default new Layout()

--- a/src/utils/math/transformNumeric.ts
+++ b/src/utils/math/transformNumeric.ts
@@ -13,7 +13,7 @@ export default function transformNumeric(value?: number | string): string {
    * When given value is zero then its generated as it is, no suffix is attached
    */
   const suffix =
-    typeof value === 'number' && value !== 0 ? Layout.options.defaultUnit : ''
+    typeof value === 'number' && value !== 0 ? Layout.defaultUnit : ''
 
   return `${value}${suffix}`
 }

--- a/src/utils/strings/parsePropName/parsePropName.ts
+++ b/src/utils/strings/parsePropName/parsePropName.ts
@@ -48,17 +48,17 @@ export default function parsePropName(originPropName: string): ParsedProp {
    */
   const normalizedBreakpointName = breakpointName
     ? toLowerCaseFirst(breakpointName)
-    : Layout.options.defaultBreakpointName
+    : Layout.defaultBreakpointName
 
   const isDefaultBreakpoint =
-    normalizedBreakpointName === Layout.options.defaultBreakpointName
+    normalizedBreakpointName === Layout.defaultBreakpointName
 
   return {
     originPropName,
     purePropName,
     behavior: behavior
       ? toLowerCaseFirst<BreakpointBehavior>(behavior)
-      : Layout.options.defaultBehavior,
+      : Layout.defaultBehavior,
     breakpoint: {
       name: normalizedBreakpointName,
       isDefault: isDefaultBreakpoint,

--- a/src/utils/styles/applyStyles/applyStyles.ts
+++ b/src/utils/styles/applyStyles/applyStyles.ts
@@ -23,7 +23,7 @@ const createStyleString = (
    */
   const shouldWrapInMediaQuery =
     breakpointOptions &&
-    !(breakpoint.isDefault && behavior === Layout.options.defaultBehavior)
+    !(breakpoint.isDefault && behavior === Layout.defaultBehavior)
 
   return shouldWrapInMediaQuery
     ? `@media ${createMediaQuery(breakpointOptions, behavior)} {${styleProps}}`


### PR DESCRIPTION
# Change log

- Moves Layout options from the dedicated `options` key to the root level of the Layout class
- Adjusts usage surface of `Layout` instance

# GitHub

- Closes #153 
