### PR TITLE
Removes bundle size check from "prepush" hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "yarn test:unit && yarn test:e2e",
     "bundlesize": "node_modules/.bin/bundlesize",
     "precommit": "lint-staged",
-    "prepush": "yarn bundlesize && yarn test:unit",
+    "prepush": "yarn test:unit",
     "prepublishOnly": "yarn build && yarn bundlesize && yarn test"
   },
   "lint-staged": {


### PR DESCRIPTION
# Change log

- Removes `yarn bundlesize` from `prepush` hook
- Leaving `yarn bundlesize` on `prepublishOnly` hook, because it performs `yarn build` before doing the size check

# GitHub

- Closes #161 
