### PR TITLE
Layout: Calls "configure" only when options are provided

### DIFF
--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -15,7 +15,7 @@ class Layout {
   protected isConfigureCalled: boolean = false
 
   constructor(options?: Partial<LayoutOptions>) {
-    return this.configure(options, false)
+    return options ? this.configure(options, false) : this
   }
 
   /**


### PR DESCRIPTION
# Change log

- Provides explicit check for `options` during instantiating a new `Layout` class
- Fixes an issue that resulted into "missing options" error being thrown by default

# GitHub

- Fixes #173 

> I will ship a succeeding pull request to improve uni test coverage on `Layout` class to improve its sustainability to changes.
