### PR TITLE
Improves Layout test coverage

### DIFF
--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -6,6 +6,7 @@ import defaultOptions, {
   BreakpointBehavior,
 } from './const/defaultOptions'
 import invariant from './utils/invariant'
+import warn from './utils/functions/warn'
 
 class Layout {
   public defaultUnit: MeasurementUnit = defaultOptions.defaultUnit
@@ -23,7 +24,7 @@ class Layout {
    */
   public configure(options: Partial<LayoutOptions>, warnOnMultiple = true) {
     if (warnOnMultiple) {
-      invariant(
+      warn(
         !this.isConfigureCalled,
         'Failed to configure Layout: do not call `Layout.configure()` more than once. Layout configuration must remain consistent throughout the application.',
       )
@@ -31,8 +32,7 @@ class Layout {
 
     invariant(
       options && typeof options === 'object',
-      'Failed to configure Layout: expected an options Object, but got: %o.',
-      options,
+      `Failed to configure Layout: expected an options Object, but got: ${options}.`,
     )
 
     Object.keys(options || {}).forEach((optionName) => {
@@ -46,23 +46,25 @@ class Layout {
 
     invariant(
       this.breakpoints.hasOwnProperty(this.defaultBreakpointName),
-      'Failed to configure Layout: cannot use "%s" as the default breakpoint (breakpoint not found).',
-      this.defaultBreakpointName,
+      `Failed to configure Layout: cannot use "${
+        this.defaultBreakpointName
+      }" as the default breakpoint (breakpoint not found).`,
     )
 
     invariant(
       this.defaultBreakpointName,
-      'Failed to configure Layout: expected "defaultBreakpointName" property set, but got: %s.',
-      this.defaultBreakpointName,
+      `Failed to configure Layout: expected "defaultBreakpointName" property set, but got: ${
+        this.defaultBreakpointName
+      }.`,
     )
 
-    invariant(
-      typeof this.defaultBreakpointName === 'string',
-      'Failed to configure Layout: expected "defaultBreakpointName" to be a string, but got: %s',
-      typeof this.defaultBreakpointName,
-    )
+    // invariant(
+    //   typeof this.defaultBreakpointName === 'string',
+    //   `Failed to configure Layout: expected "defaultBreakpointName" to be a string, but got: ${typeof this
+    //     .defaultBreakpointName}`,
+    // )
 
-    /* Mark configure method as called to prevent its multiple calls */
+    // Mark configure method as called to prevent its multiple calls
     this.isConfigureCalled = warnOnMultiple
 
     return this

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -4,7 +4,7 @@ import { GenericProps, GridProps } from '@const/props'
 import { AreasMap } from '@utils/templates/generateComponents'
 import parseTemplates from '@utils/templates/parseTemplates'
 import applyStyles from '@utils/styles/applyStyles'
-import invariant from '@utils/invariant'
+import warn from '@utils/functions/warn'
 
 type ChildrenFunction = (areas: AreasMap) => React.ReactNode
 
@@ -30,15 +30,15 @@ const Composition: React.FunctionComponent<CompositionProps> = ({
   const childrenType = typeof children
   const hasChildrenFunction = childrenType === 'function'
 
-  /**
-   * Warn on attempt to use template props without children-as-function.
-   * Render in that case still occurs, but it doesn't produce the expected result.
-   */
-  invariant(
+  // Warn on attempt to use "areas"/"template" props without children-as-function.
+  // Render in that case still occurs, but it doesn't produce the expected result.
+  warn(
     !(hasAreaComponents && !hasChildrenFunction),
-    'Failed to render `Composition` with template areas ["%s"]: expected children to be a function, but got: %s. Please provide render function as children, or remove assigned template props.',
-    Object.keys(areaComponents).join('", "'),
-    childrenType,
+    `Failed to render 'Composition' with template areas ["${Object.keys(
+      areaComponents,
+    ).join(
+      '", "',
+    )}"]: expected children to be a function, but got: ${childrenType}. Please provide render function as children, or remove assigned template props.`,
   )
 
   return (

--- a/src/utils/functions/warn/index.ts
+++ b/src/utils/functions/warn/index.ts
@@ -1,0 +1,2 @@
+export { default } from './warn'
+export * from './warn'

--- a/src/utils/functions/warn/warn.spec.ts
+++ b/src/utils/functions/warn/warn.spec.ts
@@ -1,0 +1,40 @@
+import warn from './warn'
+
+describe('warn', () => {
+  describe('warns when not satisfied predicate', () => {
+    const values = [
+      ['0', 0],
+      ['false', false],
+      ['null', null],
+      ['undefined', undefined],
+    ]
+
+    values.forEach(([name, value]) => {
+      it(`when given ${name}`, () => {
+        const consoleSpy = jest.spyOn(console, 'warn')
+        const message = 'Warning message'
+
+        warn(value, message)
+        expect(consoleSpy).toBeCalledTimes(1)
+        expect(consoleSpy).toBeCalledWith(message)
+
+        consoleSpy.mockRestore()
+      })
+    })
+  })
+
+  describe('does nothing when satisfies predicate', () => {
+    const values = [['one', 1], ['true', true], ['object', {}], ['array', []]]
+
+    values.forEach(([name, value]) => {
+      it(`when given ${name}`, () => {
+        const consoleSpy = jest.spyOn(console, 'warn')
+
+        warn(value, 'Foo')
+        expect(consoleSpy).not.toBeCalled()
+
+        consoleSpy.mockRestore()
+      })
+    })
+  })
+})

--- a/src/utils/functions/warn/warn.ts
+++ b/src/utils/functions/warn/warn.ts
@@ -1,0 +1,5 @@
+export default function warn(predicate: any, message: string) {
+  if (!predicate) {
+    console.warn(message)
+  }
+}

--- a/src/utils/invariant/invariant.spec.ts
+++ b/src/utils/invariant/invariant.spec.ts
@@ -1,24 +1,15 @@
 import invariant from './invariant'
 
-const createConsoleSpy = () => jest.spyOn(console, 'error')
-
 describe('invariant', () => {
   it('errors when predicate is not satisfied', () => {
-    const consoleError = createConsoleSpy()
     const errorMessage = 'Error message'
+    const run = () => invariant(false, errorMessage)
 
-    invariant(false, errorMessage)
-    expect(consoleError).toBeCalledWith(errorMessage)
-
-    consoleError.mockRestore()
+    expect(run).toThrowError(errorMessage)
   })
 
-  it('idle when predicate is satisfied', () => {
-    const consoleError = createConsoleSpy()
-
-    invariant(true, 'You should not see this')
-    expect(consoleError).not.toBeCalled()
-
-    consoleError.mockRestore()
+  it('does nothing on truthy predicate', () => {
+    const run = () => invariant(true, 'You should not see this')
+    expect(run).not.toThrow()
   })
 })

--- a/src/utils/invariant/invariant.ts
+++ b/src/utils/invariant/invariant.ts
@@ -1,9 +1,5 @@
-export default function invariant(
-  variable: any,
-  message: string,
-  ...messageArgs: any[]
-): void {
+export default function invariant(variable: any, message: string): void {
   if (!variable) {
-    console.error(message, ...messageArgs)
+    throw new Error(message)
   }
 }


### PR DESCRIPTION
# Change log

- Adds `warn` util
- Throws error instead of `console.error` in `invariant`
- Improves unit tests for `Layout` class

# GitHub

- Closes #177
- Relates to #173 
