### PR TITLE
Layout: Removes "getBreakpoint" and "getBreakpointNames" methods

### DIFF
--- a/src/Layout.spec.ts
+++ b/src/Layout.spec.ts
@@ -31,7 +31,7 @@ describe('Layout', () => {
   })
 
   describe('exports public API', () => {
-    const publicApi = ['configure', 'getBreakpoint', 'getBreakpointNames']
+    const publicApi = ['configure']
 
     publicApi.forEach((propName) => {
       it(propName, () => {
@@ -111,98 +111,6 @@ describe('Layout', () => {
             })
           })
         })
-      })
-    })
-  })
-
-  describe('getBreakpointNames()', () => {
-    describe('with default breakpoints', () => {
-      it('returns list of breakpoint names', () => {
-        expect(Layout.getBreakpointNames()).toEqual([
-          'xs',
-          'sm',
-          'md',
-          'lg',
-          'xl',
-        ])
-      })
-    })
-
-    describe('with custom breakpoints', () => {
-      beforeEach(() => {
-        Layout.configure({
-          defaultBreakpointName: 'mobile',
-          breakpoints: {
-            mobile: {
-              maxWidth: 768,
-            },
-            tablet: {
-              minWidth: 769,
-              maxWidth: 1099,
-            },
-            desktop: {
-              minWidth: 1100,
-            },
-          },
-        })
-      })
-
-      afterAll(resetLayoutOptions)
-
-      it('returns list of custom breakpoint names', () => {
-        expect(Layout.getBreakpointNames()).toEqual([
-          'mobile',
-          'tablet',
-          'desktop',
-        ])
-      })
-    })
-
-    it('throws when Layout has no breakpoints', () => {
-      const run = () =>
-        Layout.configure({
-          breakpoints: undefined,
-        })
-
-      expect(run).toThrowError(
-        'Failed to configure Layout: expected to have at least one breakpoint specified, but got none.',
-      )
-    })
-  })
-
-  describe('getBreakpoint()', () => {
-    describe('with default breakpoints', () => {
-      it('returns existing breakpoint data', () => {
-        expect(Layout.getBreakpoint('md')).toEqual(
-          defaultOptions.breakpoints.md,
-        )
-      })
-
-      it('returns "undefined" for not found breakpoint', () => {
-        expect(Layout.getBreakpoint('non-existing')).toBeUndefined()
-      })
-    })
-
-    describe('with custom breakpoints', () => {
-      beforeEach(() => {
-        Layout.configure({
-          defaultBreakpointName: 'retina',
-          breakpoints: {
-            retina: {
-              minResolution: '300dpi',
-            },
-          },
-        })
-      })
-
-      it('returns existing breakpoint data', () => {
-        expect(Layout.getBreakpoint('retina')).toEqual({
-          minResolution: '300dpi',
-        })
-      })
-
-      it('returns "undefined" for not found breakpoint', () => {
-        expect(Layout.getBreakpoint('md')).toBeUndefined()
       })
     })
   })

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -69,21 +69,6 @@ class Layout {
 
     return this
   }
-
-  /**
-   * Returns the collection of breakpoint names present
-   * in the current layout configuration.
-   */
-  public getBreakpointNames(): string[] {
-    return Object.keys(this.breakpoints)
-  }
-
-  /**
-   * Returns breakpoint options by the given breakpoint name.
-   */
-  public getBreakpoint(breakpointName: string): Breakpoint | undefined {
-    return this.breakpoints[breakpointName]
-  }
 }
 
 export default new Layout()

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -33,7 +33,7 @@ export interface OnlyProps extends GenericProps {
 
 const resolveBreakpoint = (breakpointRef: BreakpointRef): Breakpoint => {
   return typeof breakpointRef === 'string'
-    ? Layout.getBreakpoint(breakpointRef)
+    ? Layout.breakpoints[breakpointRef]
     : breakpointRef
 }
 

--- a/src/utils/breakpoints/getAreaBreakpoints/getAreaBreakpoints.spec.ts
+++ b/src/utils/breakpoints/getAreaBreakpoints/getAreaBreakpoints.spec.ts
@@ -22,8 +22,8 @@ describe('getAreaBreakpoints', () => {
     })
 
     it('renders inclusive area conditionally', () => {
-      const breakpointMd = Layout.getBreakpoint('md') || {}
-      const breakpointXl = Layout.getBreakpoint('xl') || {}
+      const breakpointMd = Layout.breakpoints.md || {}
+      const breakpointXl = Layout.breakpoints.xl || {}
 
       const { templates } = getAreasList({
         template: ['a'],
@@ -45,9 +45,9 @@ describe('getAreaBreakpoints', () => {
     })
 
     it('renders notch area conditionally', () => {
-      const breakpointXs = Layout.getBreakpoint('xs') || {}
-      const breakpointMd = Layout.getBreakpoint('md') || {}
-      const breakpointXl = Layout.getBreakpoint('xl') || {}
+      const breakpointXs = Layout.breakpoints.xs || {}
+      const breakpointMd = Layout.breakpoints.md || {}
+      const breakpointXl = Layout.breakpoints.xl || {}
 
       const { templates } = getAreasList({
         template: ['a', 'b'],
@@ -72,8 +72,8 @@ describe('getAreaBreakpoints', () => {
 
     describe('Shuffled behavior', () => {
       it('concatenates sibling areas with "down" behavior', () => {
-        const breakpointSm = Layout.getBreakpoint('sm') || {}
-        const breakpointMd = Layout.getBreakpoint('md') || {}
+        const breakpointSm = Layout.breakpoints.sm || {}
+        const breakpointMd = Layout.breakpoints.md || {}
 
         const { templates } = getAreasList({
           template: ['a'],
@@ -110,8 +110,8 @@ describe('getAreaBreakpoints', () => {
       })
 
       it('notch behavior using explicit "down" area behavior', () => {
-        const breakpointXs = Layout.getBreakpoint('xs') || {}
-        const breakpointMd = Layout.getBreakpoint('md') || {}
+        const breakpointXs = Layout.breakpoints.xs || {}
+        const breakpointMd = Layout.breakpoints.md || {}
 
         const { templates } = getAreasList({
           templateDown: ['a'],

--- a/src/utils/strings/parsePropName/parsePropName.ts
+++ b/src/utils/strings/parsePropName/parsePropName.ts
@@ -25,7 +25,7 @@ export interface ParsedProp {
  * lookbehind is supported everywhere.
  */
 export default function parsePropName(originPropName: string): ParsedProp {
-  const joinedBreakpointNames = Layout.getBreakpointNames().join('|')
+  const joinedBreakpointNames = Object.keys(Layout.breakpoints).join('|')
   const joinedBehaviors = ['down', 'only'].join('|')
   const breakpointExp = new RegExp(`(${joinedBreakpointNames})$`, 'gi')
   const behaviorExp = new RegExp(`(${joinedBehaviors})$`, 'gi')

--- a/src/utils/styles/applyStyles/applyStyles.ts
+++ b/src/utils/styles/applyStyles/applyStyles.ts
@@ -15,7 +15,7 @@ const createStyleString = (
     .map((propName) => `${propName}:${String(propValue)};`)
     .join('')
 
-  const breakpointOptions = Layout.getBreakpoint(breakpoint.name)
+  const breakpointOptions = Layout.breakpoints[breakpoint.name]
 
   /**
    * Wrap CSS rule in a media query only if its prop includes

--- a/src/utils/templates/getAreasList/getAreasList.spec.ts
+++ b/src/utils/templates/getAreasList/getAreasList.spec.ts
@@ -18,7 +18,7 @@ describe('getAreasList', () => {
         {
           areas: ['a', 'b'],
           behavior: 'up',
-          breakpoint: Layout.getBreakpoint('xs'),
+          breakpoint: Layout.breakpoints.xs,
         },
       ],
     })
@@ -38,12 +38,12 @@ describe('getAreasList', () => {
         {
           areas: ['a', 'b'],
           behavior: 'up',
-          breakpoint: Layout.getBreakpoint('xs'),
+          breakpoint: Layout.breakpoints.xs,
         },
         {
           areas: ['a', 'b', 'c'],
           behavior: 'up',
-          breakpoint: Layout.getBreakpoint('md'),
+          breakpoint: Layout.breakpoints.md,
         },
       ],
     })
@@ -63,12 +63,12 @@ describe('getAreasList', () => {
         {
           areas: ['a', 'b'],
           behavior: 'up',
-          breakpoint: Layout.getBreakpoint('xs'),
+          breakpoint: Layout.breakpoints.xs,
         },
         {
           areas: ['c'],
           behavior: 'down',
-          breakpoint: Layout.getBreakpoint('md'),
+          breakpoint: Layout.breakpoints.md,
         },
       ],
     })
@@ -88,12 +88,12 @@ describe('getAreasList', () => {
         {
           areas: ['a'],
           behavior: 'up',
-          breakpoint: Layout.getBreakpoint('xs'),
+          breakpoint: Layout.breakpoints.xs,
         },
         {
           areas: ['b', 'c'],
           behavior: 'only',
-          breakpoint: Layout.getBreakpoint('md'),
+          breakpoint: Layout.breakpoints.md,
         },
       ],
     })

--- a/src/utils/templates/getAreasList/getAreasList.ts
+++ b/src/utils/templates/getAreasList/getAreasList.ts
@@ -23,7 +23,7 @@ export default function getAreasList(templateProps: TemplateProps): AreasList {
       const { breakpoint, behavior } = parsePropName(templateName)
       const nextAreas = acc.areas.concat(templateAreas)
       const nextTemplates = acc.templates.concat({
-        breakpoint: Layout.getBreakpoint(breakpoint.name),
+        breakpoint: Layout.breakpoints[breakpoint.name],
         behavior,
         areas: templateAreas,
       })


### PR DESCRIPTION
# Change log

- Removes `Layout.getBreakpoint()` and `Layout.getBreakpointNames()` methods in favor of native `Layout.breakpoints[breakpointName]` and `Object.keys(Layout.breakpoints`:

```diff
- Layout.getBreakpoint('md')
+ Layout.breakpoints.md

- Layout.getBreakpointsNames()
+ Object.keys(Layout.breakpoints)
```

- Adjusts internal usage of the removed methods

# GitHub

- No particular issue
