### PR TITLE
useViewportChange: Sets faster default debounce duration

### DIFF
--- a/examples/Hooks/UseResponsiveProps.jsx
+++ b/examples/Hooks/UseResponsiveProps.jsx
@@ -38,6 +38,7 @@ const UseResponsivePropsExample = () => (
     sizeMd={75}
     sizeLg={100}
     // Bell
+    fontSize={16}
     fontSizeSm={20}
     fontSizeLg={16}
     // Notch

--- a/src/hooks/useBreakpointChange.ts
+++ b/src/hooks/useBreakpointChange.ts
@@ -22,7 +22,7 @@ const useBreakpointChange = (
       callback(nextBreakpointName)
       prevBreakpointName = nextBreakpointName
     }
-  })
+  }, debounceDuration)
 }
 
 export default useBreakpointChange

--- a/src/hooks/useViewportChange.ts
+++ b/src/hooks/useViewportChange.ts
@@ -4,7 +4,10 @@ import debounce from '@utils/functions/debounce'
 /**
  * Executes a given callback on debounced window resize.
  */
-const useViewportChange = (callback: () => void, debounceDuration?: number) => {
+const useViewportChange = (
+  callback: () => void,
+  debounceDuration: number = 50,
+) => {
   const handleWindowResize = debounce(callback, debounceDuration)
 
   useEffect(() => {


### PR DESCRIPTION
# Change log

- Fixes issue where custom `debounceDuration` wasn't propagated to the underlying `useViewportChange` hook in `useBreakpointChange` hook
- Sets default debounce duration of `useViewportChange` to `50ms` to improve re-render speed upon viewport changes

# GitHub

- Closes #167 
