### PR TITLE
Introduces "Areas" grouped area component

### DIFF
--- a/cypress/integration/composition/index.js
+++ b/cypress/integration/composition/index.js
@@ -1,4 +1,5 @@
 describe('Composition', () => {
   require('./nested-composition.test')
   require('./templateless.test')
+  require('./namespace.test')
 })

--- a/cypress/integration/composition/namespace.test.js
+++ b/cypress/integration/composition/namespace.test.js
@@ -1,0 +1,15 @@
+describe('Namespace collision', () => {
+  before(() => {
+    cy.loadStory(['components'], ['composition', 'namespace'])
+  })
+
+  it('Renders children without crashing', () => {
+    cy.get('#composition').assertAreas([['logo', 'menu', 'actions']])
+  })
+
+  it('Renders custom components without collision', () => {
+    cy.get('[data-area="logo"]').should('have.text', 'Logo')
+    cy.get('[data-area="menu"]').should('have.text', 'Menu')
+    cy.get('[data-area="actions"]').should('have.text', 'Actions')
+  })
+})

--- a/examples/Components/Composition/Namespace.jsx
+++ b/examples/Components/Composition/Namespace.jsx
@@ -5,18 +5,18 @@ const Logo = () => <span>Logo</span>
 const Menu = () => <span>Menu</span>
 
 const Namespaces = () => (
-  <Composition areas="logo menu actions">
-    {({ Areas }) => (
+  <Composition id="composition" areas="logo menu actions">
+    {({ Areas, Actions }) => (
       <>
-        <Areas.Logo>
+        <Areas.Logo data-area="logo">
           <Logo />
         </Areas.Logo>
-        <Areas.Menu>
+        <Areas.Menu data-area="menu">
           <Menu />
         </Areas.Menu>
-        <Areas.Actions>
+        <Actions data-area="actions">
           <span>Actions</span>
-        </Areas.Actions>
+        </Actions>
       </>
     )}
   </Composition>

--- a/examples/Components/Composition/Namespace.jsx
+++ b/examples/Components/Composition/Namespace.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Composition } from 'atomic-layout'
+
+const Logo = () => <span>Logo</span>
+const Menu = () => <span>Menu</span>
+
+const Namespaces = () => (
+  <Composition areas="logo menu actions">
+    {({ Areas }) => (
+      <>
+        <Areas.Logo>
+          <Logo />
+        </Areas.Logo>
+        <Areas.Menu>
+          <Menu />
+        </Areas.Menu>
+        <Areas.Actions>
+          <span>Actions</span>
+        </Areas.Actions>
+      </>
+    )}
+  </Composition>
+)
+
+export default Namespaces

--- a/examples/index.js
+++ b/examples/index.js
@@ -43,10 +43,12 @@ storiesOf('Core|Configuration', module)
  */
 import NestedComposition from './Components/Composition/NestedComposition'
 import Templateless from './Components/Composition/Templateless'
+import Namespace from './Components/Composition/Namespace'
 
 storiesOf('Components|Composition', module)
   .add('Nested composition', () => <NestedComposition />)
   .add('Templateless', () => <Templateless />)
+  .add('Namespace', () => <Namespace />)
 
 /**
  * Only

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "no-console": false,
     "prefer-template": [true, "always"],
     "no-bitwise": false,
+    "prefer-object-spread": false,
 
     "ordered-imports": [false, "never"],
     "object-literal-sort-keys": [false, "never"],


### PR DESCRIPTION
Addresses a namespace collision issue between own React components and those areas components generated by the library.

## Change log

- Introduces a designated `Areas` namespace that holds all the generated area components

## GitHub

- Closes #154 

## Roadmap

- [x] Add integration test asserting the grouped areas
