### PR TITLE
ESM: Provides "__PROD__" environmental variable

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -3,6 +3,8 @@ const path = require('path')
 module.exports = async ({ config }) => {
   const target = process.env.TARGET || 'cjs'
 
+  console.log(`\nBundling "atomic-layout" build for "${target}" module...\n`)
+
   config.resolve.alias = {
     'atomic-layout': path.resolve(__dirname, `../${target}`),
     '@stories': path.resolve(__dirname, '../examples'),

--- a/cypress/integration/composition/index.js
+++ b/cypress/integration/composition/index.js
@@ -1,5 +1,6 @@
 describe('Composition', () => {
   require('./nested-composition.test')
   require('./templateless.test')
+  require('./weak-area.test')
   require('./namespace.test')
 })

--- a/cypress/integration/composition/weak-area.test.js
+++ b/cypress/integration/composition/weak-area.test.js
@@ -1,0 +1,37 @@
+describe('Weak area rendering', () => {
+  before(() => {
+    cy.loadStory(['components'], ['composition', 'weak-area'])
+  })
+
+  describe('on extra-small screen', () => {
+    before(() => {
+      cy.setBreakpoint('sm')
+    })
+
+    it('Renders existing areas', () => {
+      cy.get('#composition').assertAreas([['left', 'right']])
+    })
+
+    it('Does not render weak area', () => {
+      cy.get('#center').should('not.exist')
+    })
+
+    it('Does not render undefined area', () => {
+      cy.get('#extra').should('not.exist')
+    })
+  })
+
+  describe('on medium screen', () => {
+    before(() => {
+      cy.setBreakpoint('md')
+    })
+
+    it('Renders all areas', () => {
+      cy.get('#composition').assertAreas([['left', 'center', 'right']])
+    })
+
+    it('Does not render undefined area', () => {
+      cy.get('#extra').should('not.exist')
+    })
+  })
+})

--- a/examples/Components/Composition/WeakArea.jsx
+++ b/examples/Components/Composition/WeakArea.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Composition } from 'atomic-layout'
+import Square from '@stories/Square'
+
+const WeakAreaRendering = () => (
+  <Composition
+    id="composition"
+    areas="left right"
+    areasMd="left center right"
+    gap={10}
+  >
+    {({ Left, Center, Right, Extra }) => (
+      <>
+        <Left data-area="left">
+          <Square>Left</Square>
+        </Left>
+        {/* Area present only in some definitions */}
+        <Center data-area="center">
+          <Square>Center</Square>
+        </Center>
+        <Right data-area="right">
+          <Square>Right</Square>
+        </Right>
+        {/* Undefined area component */}
+        <Extra data-area="extra">Foo</Extra>
+      </>
+    )}
+  </Composition>
+)
+
+export default WeakAreaRendering

--- a/examples/index.js
+++ b/examples/index.js
@@ -44,10 +44,12 @@ storiesOf('Core|Configuration', module)
 import NestedComposition from './Components/Composition/NestedComposition'
 import Templateless from './Components/Composition/Templateless'
 import Namespace from './Components/Composition/Namespace'
+import WeakArea from './Components/Composition/WeakArea'
 
 storiesOf('Components|Composition', module)
   .add('Nested composition', () => <NestedComposition />)
   .add('Templateless', () => <Templateless />)
+  .add('Weak area', () => <WeakArea />)
   .add('Namespace', () => <Namespace />)
 
 /**

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,15 +10,15 @@ import { terser } from 'rollup-plugin-terser'
 import packageJson from './package.json'
 
 // Import as CJS since writing Babel config in ES
-// makes it unreadable by other tools (i.e. storybook).
+// makes it unreadable by other tools (i.e. Storybook).
 const babelConfig = require('./babel.config')
+
 const BUILD_DIR = '.'
 const getPath = (filepath) => {
   return path.resolve(BUILD_DIR, filepath)
 }
 
-const nodeEnv = process.env.NODE_ENV
-const target = process.env.TARGET
+const { NODE_ENV: nodeEnv, TARGET: target } = process.env
 const PRODUCTION = nodeEnv === 'production'
 const __PROD__ = PRODUCTION ? 'true' : ''
 const input = packageJson.esnext
@@ -134,6 +134,9 @@ const buildEsm = () => ({
   },
   plugins: [
     resolve(),
+    replace({
+      __PROD__,
+    }),
     typescript(),
     babel(babelConfig),
     PRODUCTION && sourceMaps(),
@@ -146,4 +149,4 @@ const buildTargets = {
   esm: buildEsm(),
 }
 
-export default (target ? buildTargets[target] : Object.values(buildTargets))
+export default target ? buildTargets[target] : Object.values(buildTargets)


### PR DESCRIPTION
# Change log

- Replaces `__PROD__` environmental variable with the actual value depending on the build
- Adds integration scenario for weak and non-existing areas rendering (Composition)
- Improves debugging of Storybook builds

# GitHub

- Closes #199
