### PR TITLE
Box: Assigns "display" property aside from priority styles

### DIFF
--- a/cypress/integration/bugfixes/box-display-override.test.js
+++ b/cypress/integration/bugfixes/box-display-override.test.js
@@ -1,0 +1,7 @@
+it('Box: Allows "display" value override', () => {
+  cy.loadStory(['bugfixes'], ['all', 'box-display-override'])
+
+  cy.get('#box')
+    .should('be.visible')
+    .should('have.css', 'display', 'table')
+})

--- a/cypress/integration/bugfixes/index.js
+++ b/cypress/integration/bugfixes/index.js
@@ -1,4 +1,5 @@
 describe('Bugfixes', () => {
   require('./template-indentation.test')
   require('./styles-undefined.test')
+  require('./box-display-override.test')
 })

--- a/cypress/integration/other/polymorphic-prop.spec.js
+++ b/cypress/integration/other/polymorphic-prop.spec.js
@@ -27,7 +27,7 @@ describe('Polymorphic prop', () => {
 
     it('overrides layout styles', () => {
       cy.get('#header')
-        .should('have.css', 'display', 'flex')
+        .should('have.css', 'display', 'block')
         .should('have.css', 'padding', '20px')
     })
   })

--- a/examples/Bugfixes/BoxDisplayOverride.jsx
+++ b/examples/Bugfixes/BoxDisplayOverride.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Box } from 'atomic-layout'
+
+const StyledBox = styled.div`
+  display: table;
+`
+
+const MediaQueryStory = () => {
+  return (
+    <Box as={StyledBox} id="box">
+      Content
+    </Box>
+  )
+}
+
+export default MediaQueryStory

--- a/examples/Bugfixes/TemplateIndentation.jsx
+++ b/examples/Bugfixes/TemplateIndentation.jsx
@@ -10,14 +10,14 @@ second
 const TemplateIndentation = () => (
   <Composition areas={template} gutter={10}>
     {({ First, Second }) => (
-      <React.Fragment>
+      <>
         <First id="first">
           <Square>First</Square>
         </First>
         <Second id="second">
           <Square>Second</Square>
         </Second>
-      </React.Fragment>
+      </>
     )}
   </Composition>
 )

--- a/examples/Core/Configuration/CustomBreakpoints.jsx
+++ b/examples/Core/Configuration/CustomBreakpoints.jsx
@@ -38,14 +38,14 @@ export default class CustomBreakpoints extends React.Component {
         paddingDesktop={3}
       >
         {({ First, Second }) => (
-          <React.Fragment>
+          <>
             <First>
               <Square>First</Square>
             </First>
             <Second>
               <Square>Second</Square>
             </Second>
-          </React.Fragment>
+          </>
         )}
       </Composition>
     )

--- a/examples/Core/Rendering/PolymorphicProp.jsx
+++ b/examples/Core/Rendering/PolymorphicProp.jsx
@@ -12,8 +12,8 @@ const CustomHeader = styled.header`
 const PolymorphicProp = () => (
   <Composition areas="header main element footer" gutter={10}>
     {({ Header, Main, Element, Footer }) => (
-      <React.Fragment>
-        <Header flex as={CustomHeader} id="header" padding={20}>
+      <>
+        <Header as={CustomHeader} flex id="header" padding={20}>
           <Square>Header</Square>
         </Header>
         <Main as="main" id="main">
@@ -25,7 +25,7 @@ const PolymorphicProp = () => (
         <Footer as="footer" id="footer">
           <Square>Footer</Square>
         </Footer>
-      </React.Fragment>
+      </>
     )}
   </Composition>
 )

--- a/examples/index.js
+++ b/examples/index.js
@@ -93,10 +93,12 @@ storiesOf('Recipes|All', module)
  */
 import StylesUndefined from './Bugfixes/StylesUndefined'
 import TemplateIndentation from './Bugfixes/TemplateIndentation'
+import BoxDisplayOverride from './Bugfixes/BoxDisplayOverride'
 
 storiesOf('Bugfixes|All', module)
   .add('Styles undefined', () => <StylesUndefined />)
   .add('Template indentation', () => <TemplateIndentation />)
+  .add('Box display override', () => <BoxDisplayOverride />)
 
 /**
  * Playground

--- a/src/components/Box.spec.tsx
+++ b/src/components/Box.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import Box from './Box'
+import styled from 'styled-components'
 import { render, cleanup, getByText } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import Box from './Box'
 
 describe('Box', () => {
   afterEach(cleanup)
@@ -9,6 +10,7 @@ describe('Box', () => {
   it('renders default Box', () => {
     const { container } = render(<Box padding={10}>Content</Box>)
     const renderedBox = getByText(container, 'Content')
+
     expect(renderedBox).toHaveTextContent('Content')
     expect(renderedBox).toHaveStyle('display:block')
     expect(renderedBox).toHaveStyle('padding:10px')
@@ -21,6 +23,7 @@ describe('Box', () => {
       </Box>,
     )
     const renderedBox = getByText(container, 'Content')
+
     expect(renderedBox).toHaveTextContent('Content')
     expect(renderedBox).toHaveStyle('display:inline-block')
   })
@@ -32,6 +35,7 @@ describe('Box', () => {
       </Box>,
     )
     const renderedBlock = getByText(container, 'Content')
+
     expect(renderedBlock).toHaveTextContent('Content')
     expect(renderedBlock).toHaveStyle('display:flex')
     expect(renderedBlock).toHaveStyle('align-items:center')
@@ -44,6 +48,7 @@ describe('Box', () => {
       </Box>,
     )
     const renderedBlock = getByText(container, 'Content')
+
     expect(renderedBlock).toHaveTextContent('Content')
     expect(renderedBlock).toHaveStyle('display:inline-flex')
     expect(renderedBlock).toHaveStyle('justify-content:center')

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -10,16 +10,17 @@ export interface BoxProps extends GenericProps {
 }
 
 const Box: React.FunctionComponent<BoxProps> = styled.div<BoxProps>`
+  display: ${({ flex, inline }) =>
+    flex
+      ? inline
+        ? 'inline-flex'
+        : 'flex'
+      : inline
+      ? 'inline-block'
+      : 'block'};
+
   && {
     ${applyStyles};
-    display: ${({ flex, inline }) =>
-      flex
-        ? inline
-          ? 'inline-flex'
-          : 'flex'
-        : inline
-        ? 'inline-block'
-        : 'block'};
   }
 `
 


### PR DESCRIPTION
# Change log

- Moves `display` CSS property assignment in the Box component to the root level of a styled component (previously wrapped in a prioritizing `&&`)
- Adds missing end-to-end test that ensures that Box's `display` can be overridden by the same CSS property of a custom styled component

# GitHub

- Closes #202 
