### PR TITLE
Hooks: Adds "useResponsiveComponent" hook

### DIFF
--- a/examples/Hooks/UseResponsiveComponent.jsx
+++ b/examples/Hooks/UseResponsiveComponent.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import styled from 'styled-components'
+import { withResponsiveProps } from 'atomic-layout'
+
+const Text = withResponsiveProps(styled.h1`
+  color: ${({ color }) => color};
+  font-size: ${({ size }) => size}px;
+`)
+
+const Scenario = () => (
+  <Text
+    size={16}
+    sizeMd={20}
+    sizeLg={24}
+    color="black"
+    colorMd="green"
+    colorLg="red"
+  >
+    Quick brown fox
+  </Text>
+)
+
+export default Scenario

--- a/examples/index.js
+++ b/examples/index.js
@@ -71,12 +71,14 @@ import UseViewportChange from './Hooks/UseViewportChange'
 import UseResponsiveValue from './Hooks/UseResponsiveValue'
 import UseBreakpointChange from './Hooks/UseBreakpointChange'
 import UseResponsiveProps from './Hooks/UseResponsiveProps'
+import UseResponsiveComponent from './Styled/UseResponsiveComponent'
 
 storiesOf('Hooks', module)
   .add('useViewportChange', () => <UseViewportChange />)
   .add('useResponsiveValue', () => <UseResponsiveValue />)
   .add('useBreakpointChange', () => <UseBreakpointChange />)
   .add('useResponsiveProps', () => <UseResponsiveProps />)
+  .add('useResponsiveComponent', () => <UseResponsiveComponent />)
 
 /**
  * Recipes

--- a/src/hooks/useResponsiveComponent.tsx
+++ b/src/hooks/useResponsiveComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import useResponsiveProps from './useResponsiveProps'
+
+/**
+ * Returns a copy of the given React component
+ * that supports Responsive Props API.
+ */
+function withResponsiveProps<
+  OwnProps = Record<string, any>,
+  ResponsiveProps = Record<string, any>
+>(
+  Component: React.FunctionComponent<OwnProps>,
+): React.FunctionComponent<OwnProps & Partial<ResponsiveProps>> {
+  return (responsiveProps) => {
+    /**
+     * @todo Typing this needs some help.
+     */
+    const actualProps: any = useResponsiveProps(responsiveProps)
+    return <Component {...actualProps} />
+  }
+}
+
+export default withResponsiveProps

--- a/src/hooks/useResponsiveProps.ts
+++ b/src/hooks/useResponsiveProps.ts
@@ -9,12 +9,12 @@ import createMediaQuery from '@utils/styles/createMediaQuery'
  * an object of props relative to the current viewport.
  */
 const useResponsiveProps = <ResponsiveProps = {}>(
-  responsiveProps: ResponsiveProps,
-) => {
-  const [props, setProps] = useState({})
+  responsiveProps: Object,
+): Partial<ResponsiveProps> => {
+  const [props, setProps] = useState<ResponsiveProps>({})
 
   useBreakpointChange(() => {
-    const relevantProps = Object.keys(responsiveProps)
+    const nextProps = Object.keys(responsiveProps)
       .map(parsePropName)
       .filter(({ breakpoint, behavior }) => {
         const mediaQuery = createMediaQuery(
@@ -23,15 +23,15 @@ const useResponsiveProps = <ResponsiveProps = {}>(
         )
         return matchMedia(mediaQuery).matches
       })
-      .reduce(
+      .reduce<ResponsiveProps>(
         (acc, { originPropName, purePropName }) => ({
           ...acc,
           [purePropName]: responsiveProps[originPropName],
         }),
-        {},
+        {} as ResponsiveProps,
       )
 
-    setProps(relevantProps)
+    setProps(nextProps)
   })
 
   return props

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { default as useViewportChange } from './hooks/useViewportChange'
 export { default as useResponsiveValue } from './hooks/useResponsiveValue'
 export { default as useBreakpointChange } from './hooks/useBreakpointChange'
 export { default as useResponsiveProps } from './hooks/useResponsiveProps'
+export { default as withResponsiveProps } from './hooks/useResponsiveComponent'
 
 /* Utils */
 export { default as withBreakpoints } from '@utils/breakpoints/withBreakpoints'


### PR DESCRIPTION
## Change log

- Adds a new `useResponsiveComponent` hook to be a shorthand for `useResponsiveProps` + React component declaration

## GitHub

- Closes #194 

## Roadmap

- [ ] Fix typing errors that fail unit tests
- [ ] See into why Storybook build is broken (build on local, ensure imports are valid, beware of the casing issues)
- [ ] Resolve conflicts with the `master` branch