### PR TITLE
Adds missing "alignContent" prop alias to the aliases map

### DIFF
--- a/src/const/propAliases.spec.tsx
+++ b/src/const/propAliases.spec.tsx
@@ -29,7 +29,7 @@ const explicitValues = {
   autoFlow: ['row', 'column', 'row dense'],
   align: 'center',
   alignItems: 'flex-end',
-  alignContent: 'flex-start',
+  alignContent: ['flex-start', 'space-around', 'space-between'],
   justify: 'center',
   justifyItems: 'flex-end',
   justifyContent: 'flex-start',

--- a/src/const/propAliases.ts
+++ b/src/const/propAliases.ts
@@ -106,6 +106,9 @@ const propAliases: PropAliases = {
   alignItems: {
     props: ['align-items'],
   },
+  alignContent: {
+    props: ['align-content'],
+  },
   justify: {
     props: ['justify-self'],
   },


### PR DESCRIPTION
# Change log

- Adds missing `alignContent` prop alias to the aliases map

# GitHub

- Closes #217
