### PR TITLE
Fix ref usage at useViewportChange cleanup

### DIFF
--- a/src/hooks/useViewportChange.ts
+++ b/src/hooks/useViewportChange.ts
@@ -16,10 +16,11 @@ const useViewportChange = (
   })
 
   useEffect(() => {
-    handleWindowResize.current()
-    window.addEventListener('resize', handleWindowResize.current)
-    return () =>
-      window.removeEventListener('resize', handleWindowResize.current)
+    const { current } = handleWindowResize
+
+    current()
+    window.addEventListener('resize', current)
+    return () => window.removeEventListener('resize', current)
   }, [])
 }
 


### PR DESCRIPTION
## Changes

I'm destructuring current from handleWindowResize ref 

## Before
![before](https://i.ibb.co/Jjp7p9w/before-atomic.gif)

## After
![after](https://i.ibb.co/ZSxw96C/after-atomic.gif)

## GitHub

- Closes #232 