### PR TITLE
Only: Extends "BoxProps" instead of "GenericProps"

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -9,7 +9,7 @@ export interface BoxProps extends GenericProps {
   inline?: boolean
 }
 
-const Box: React.FunctionComponent<BoxProps> = styled.div<BoxProps>`
+const Box: React.FC<BoxProps> = styled.div<BoxProps>`
   display: ${({ flex, inline }) =>
     flex
       ? inline

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -21,7 +21,7 @@ const CompositionWrapper = styled.div<CompositionProps>`
   }
 `
 
-const Composition: React.FunctionComponent<CompositionProps> = ({
+const Composition: React.FC<CompositionProps> = ({
   children,
   ...restProps
 }) => {

--- a/src/components/MediaQuery.tsx
+++ b/src/components/MediaQuery.tsx
@@ -5,7 +5,7 @@ import normalizeQuery from '@src/utils/styles/normalizeQuery'
 import transformNumeric from '@utils/math/transformNumeric'
 import compose from '@src/utils/functions/compose'
 
-interface Props extends MediaQueryParams {
+interface MediaQueryProps extends MediaQueryParams {
   children: (matches: boolean) => JSX.Element
   matches?: boolean
 }
@@ -30,9 +30,11 @@ const createMediaQuery = (queryParams: MediaQueryParams): string => {
   )(queryParams)
 }
 
-const MediaQuery = (props: Props): JSX.Element => {
+const MediaQuery: React.FC<MediaQueryProps> = (props) => {
   const { children, ...queryParams } = props
-  const query = React.useMemo(() => createMediaQuery(queryParams), [queryParams])
+  const query = React.useMemo(() => createMediaQuery(queryParams), [
+    queryParams,
+  ])
   const [matches, setMatches] = React.useState(false)
 
   const handleMediaQueryChange = (

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 import Layout from '../Layout'
-import Box from './Box'
+import Box, { BoxProps } from './Box'
 import { Breakpoint } from '@const/defaultOptions'
-import { GenericProps } from '@const/props'
 import { withPlaceholder } from '@utils/templates/generateComponents'
 import openBreakpoint from '@utils/breakpoints/openBreakpoint'
 import closeBreakpoint from '@utils/breakpoints/closeBreakpoint'
@@ -16,7 +15,7 @@ const resolveBreakpoint = (breakpointRef: BreakpointRef): Breakpoint => {
     : breakpointRef
 }
 
-export interface OnlyProps extends GenericProps {
+export interface OnlyProps extends BoxProps {
   /**
    * Renders children only at the specified breakpoint.
    */
@@ -37,7 +36,7 @@ export interface OnlyProps extends GenericProps {
   except?: boolean
 }
 
-const createWrapper = (children: React.ReactNode, props: GenericProps) => (
+const createWrapper = (children: React.ReactNode, props: BoxProps) => (
   ...breakpoints: Breakpoint[]
 ) => {
   const Placeholder = withPlaceholder(Box, breakpoints)

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -43,14 +43,14 @@ const createWrapper = (children: React.ReactNode, props: BoxProps) => (
   return <Placeholder {...props}>{children}</Placeholder>
 }
 
-const Only = ({
+const Only: React.FC<OnlyProps> = ({
   children,
   except,
   for: exactBreakpointName,
   from: minBreakpointName,
   to: maxBreakpointName,
   ...restProps
-}: { children: any } & OnlyProps): JSX.Element => {
+}) => {
   const wrapWith = createWrapper(children, restProps)
 
   // Render on explicit breakpoint
@@ -97,7 +97,7 @@ const Only = ({
   }
 
   // Render always when no constrains are provided
-  return children
+  return <>children</>
 }
 
 export default Only

--- a/src/const/props.ts
+++ b/src/const/props.ts
@@ -216,7 +216,7 @@ export interface GenericProps {
   paddingHorizontal?: Numeric
 }
 
-export interface GridProps extends GenericProps {
+export interface GridProps {
   /**
    * Grid area.
    * @css `grid-area`

--- a/src/hooks/useResponsiveComponent.tsx
+++ b/src/hooks/useResponsiveComponent.tsx
@@ -10,8 +10,8 @@ function useResponsiveComponent<
   OwnProps extends Record<string, any>,
   ResponsiveProps extends Record<string, Numeric>
 >(
-  Component: React.FunctionComponent<OwnProps>,
-): React.FunctionComponent<OwnProps & Partial<ResponsiveProps>> {
+  Component: React.FC<OwnProps>,
+): React.FC<OwnProps & Partial<ResponsiveProps>> {
   return (responsiveProps) => {
     /**
      * @see https://github.com/Microsoft/TypeScript/issues/29049

--- a/src/utils/templates/generateComponents/generateComponents.tsx
+++ b/src/utils/templates/generateComponents/generateComponents.tsx
@@ -5,9 +5,9 @@ import { GenericProps } from '@const/props'
 import MediaQuery from '@components/MediaQuery'
 import Box, { BoxProps } from '@components/Box'
 import capitalize from '@utils/strings/capitalize'
-import getAreaRecords, { AreaRecord } from '@utils/breakpoints/getAreaRecords'
+import getAreaRecords from '@utils/breakpoints/getAreaRecords'
 
-export type AreaComponent = React.FunctionComponent<BoxProps>
+export type AreaComponent = React.FC<BoxProps>
 export interface AreasMap {
   [componentName: string]: AreaComponent
 }
@@ -21,10 +21,7 @@ export const withPlaceholder = (
   Component: AreaComponent,
   breakpoints: Breakpoint[],
 ) => {
-  const Placeholder: React.FunctionComponent<GenericProps> = ({
-    children,
-    ...restProps
-  }) => {
+  const Placeholder: React.FC<GenericProps> = ({ children, ...restProps }) => {
     const PlaceholderComponent = breakpoints.reduce<JSX.Element[]>(
       (components, breakpoint, index) => {
         return components.concat(


### PR DESCRIPTION
## Changes

- `Only` component types now extend `BoxProps` instead of `GenericProps`. This allows for `Only` to have Box props like `flex` and `inline` plus all the generic props.

## GitHub

- Closes #246 
