### PR TITLE
Adds "Visible" component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,10 +2,8 @@ import { addParameters, configure } from '@storybook/react'
 
 addParameters({
   options: {
-    brandName: 'Atomic layout',
+    brandName: 'Atomic Layout',
     brandUrl: 'https://github.com/kettanaito/atomic-layout',
-    showPanel: false,
-    isToolshown: false,
   },
 })
 

--- a/examples/all.test.js
+++ b/examples/all.test.js
@@ -46,6 +46,10 @@ describe('Components', () => {
     require('./components/Only/OnlyDefaultBehavior.test')
     require('./components/Only/OnlyCustomBreakpoints.test')
   })
+
+  describe('Visible', () => {
+    require('./components/Visible/Visible.test')
+  })
 })
 
 /**

--- a/examples/components/Only/OnlyDefaultBehavior.test.js
+++ b/examples/components/Only/OnlyDefaultBehavior.test.js
@@ -27,7 +27,7 @@ describe('Default behavior', () => {
     cy.setBreakpoint('xl').then(() => cy.shouldRender('#third'))
   })
 
-  it('Renders children within a breakpooint range (from/to)', () => {
+  it('Renders children within a breakpoint range (from/to)', () => {
     cy.setBreakpoint('xs').then(() => cy.shouldRender('#fourth', false))
     cy.setBreakpoint('sm').then(() => cy.shouldRender('#fourth'))
     cy.setBreakpoint('md').then(() => cy.shouldRender('#fourth'))

--- a/examples/components/Visible/Visible.test.js
+++ b/examples/components/Visible/Visible.test.js
@@ -1,0 +1,115 @@
+describe('Visible', () => {
+  before(() => {
+    cy.loadStory(['components', 'only'], ['default-behavior'])
+  })
+
+  it('Displays children at the exact breakpoint (for)', () => {
+    cy.setBreakpoint('xs').then(() => {
+      cy.get('#first').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('sm').then(() => {
+      cy.get('#first').should('be.visible')
+    })
+
+    cy.setBreakpoint('md').then(() => {
+      cy.get('#first').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('lg').then(() => {
+      cy.get('#first').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('xl').then(() => {
+      cy.get('#first').should('not.be.visible')
+    })
+  })
+
+  it('Displays children up to a given breakpoint (to)', () => {
+    cy.setBreakpoint('xs').then(() => {
+      cy.get('#second').should('be.visible')
+    })
+
+    cy.setBreakpoint('sm').then(() => {
+      cy.get('#second').should('be.visible')
+    })
+
+    cy.setBreakpoint('md').then(() => {
+      cy.get('#second').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('lg').then(() => {
+      cy.get('#second').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('xl').then(() => {
+      cy.get('#second').should('not.be.visible')
+    })
+  })
+
+  it('Displays children from a given breakpoint (from)', () => {
+    cy.setBreakpoint('xs').then(() => {
+      cy.get('#third').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('sm').then(() => {
+      cy.get('#third').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('md').then(() => {
+      cy.get('#third').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('lg').then(() => {
+      cy.get('#third').should('be.visible')
+    })
+
+    cy.setBreakpoint('xl').then(() => {
+      cy.get('#third').should('be.visible')
+    })
+  })
+
+  it('Displays children within a breakpoint range (from/to)', () => {
+    cy.setBreakpoint('xs').then(() => {
+      cy.get('#fourth').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('sm').then(() => {
+      cy.get('#fourth').should('be.visible')
+    })
+
+    cy.setBreakpoint('md').then(() => {
+      cy.get('#fourth').should('be.visible')
+    })
+
+    cy.setBreakpoint('lg').then(() => {
+      cy.get('#fourth').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('xl').then(() => {
+      cy.get('#fourth').should('not.be.visible')
+    })
+  })
+
+  it('Displays children excluding a breakpoint range (except)', () => {
+    cy.setBreakpoint('xs').then(() => {
+      cy.get('#fifth').should('be.visible')
+    })
+
+    cy.setBreakpoint('sm').then(() => {
+      cy.get('#fifth').should('be.visible')
+    })
+
+    cy.setBreakpoint('md').then(() => {
+      cy.get('#fifth').should('not.be.visible')
+    })
+
+    cy.setBreakpoint('lg').then(() => {
+      cy.get('#fifth').should('be.visible')
+    })
+
+    cy.setBreakpoint('xl').then(() => {
+      cy.get('#fifth').should('be.visible')
+    })
+  })
+})

--- a/examples/components/Visible/VisibleDefaultBehavior.jsx
+++ b/examples/components/Visible/VisibleDefaultBehavior.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Visible } from 'atomic-layout'
+import Square from '@stories/Square'
+
+const VisibleDefaultBehavior = () => (
+  <>
+    {/* Explicit breakpoint */}
+    <Visible for="sm">
+      <Square id="first">For "sm"</Square>
+    </Visible>
+    {/* High-pass */}
+    <Visible to="md">
+      <Square id="second">To "md"</Square>
+    </Visible>
+    {/* Low-pass */}
+    <Visible from="lg">
+      <Square id="third">From "lg"</Square>
+    </Visible>
+    {/* Bell */}
+    <Visible from="sm" to="lg">
+      <Square id="fourth">From "sm" to "lg"</Square>
+    </Visible>
+    {/* Notch */}
+    <Visible except from="md" to="lg">
+      <Square id="fifth">Except from "md" to "lg"</Square>
+    </Visible>{' '}
+  </>
+)
+
+export default VisibleDefaultBehavior

--- a/examples/index.js
+++ b/examples/index.js
@@ -76,6 +76,16 @@ storiesOf('Components|Only', module)
   .add('Custom breakpoints', OnlyCustomBreakpoints)
 
 /**
+ * Visible
+ */
+import VisibleDefaultBehavior from './components/Visible/VisibleDefaultBehavior'
+
+storiesOf('Components|Visible', module).add(
+  'Default behavior',
+  VisibleDefaultBehavior,
+)
+
+/**
  * Hooks
  */
 import UseViewportChange from './hooks/UseViewportChange'

--- a/src/components/MediaQuery.tsx
+++ b/src/components/MediaQuery.tsx
@@ -1,55 +1,18 @@
 import * as React from 'react'
 import { MediaQuery as MediaQueryParams } from '@const/defaultOptions'
-import { joinQueryList } from '@utils/styles/createMediaQuery'
-import normalizeQuery from '@src/utils/styles/normalizeQuery'
-import transformNumeric from '@utils/math/transformNumeric'
-import compose from '@src/utils/functions/compose'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
 
 interface MediaQueryProps extends MediaQueryParams {
   children: (matches: boolean) => JSX.Element
   matches?: boolean
 }
 
-const createMediaQuery = (queryParams: MediaQueryParams): string => {
-  return compose(
-    joinQueryList(([paramName, paramValue]) => {
-      /**
-       * Transform values that begin with a number to prevent
-       * transformations of "calc" expressions.
-       * Transformation of numerics is necessary when a simple
-       * number is used as a value (min-width: 750) is not valid.
-       *
-       * (min-width: 750) ==> (min-width: 750px)
-       */
-      const resolvedParamValue = /^\d/.test(String(paramValue))
-        ? transformNumeric(paramValue)
-        : paramValue
-      return `(${paramName}:${resolvedParamValue})`
-    }),
-    normalizeQuery,
-  )(queryParams)
-}
-
-const MediaQuery: React.FC<MediaQueryProps> = (props) => {
-  const { children, matches: initialMatches, ...queryParams } = props
-  const query = React.useMemo(() => createMediaQuery(queryParams), [
-    queryParams,
-  ])
-  const [matches, setMatches] = React.useState(initialMatches)
-
-  const handleMediaQueryChange = (
-    mediaQueryList: MediaQueryList | MediaQueryListEvent,
-  ) => {
-    setMatches(mediaQueryList.matches)
-  }
-
-  React.useEffect(() => {
-    const mediaQueryList = matchMedia(query)
-    handleMediaQueryChange(mediaQueryList)
-    mediaQueryList.addListener(handleMediaQueryChange)
-
-    return () => mediaQueryList.removeListener(handleMediaQueryChange)
-  }, Object.keys(queryParams))
+const MediaQuery: React.FC<MediaQueryProps> = ({
+  children,
+  matches: initialMatches,
+  ...queryParams
+}) => {
+  const matches = useMediaQuery(queryParams, initialMatches)
 
   return children(matches)
 }

--- a/src/components/MediaQuery.tsx
+++ b/src/components/MediaQuery.tsx
@@ -31,11 +31,11 @@ const createMediaQuery = (queryParams: MediaQueryParams): string => {
 }
 
 const MediaQuery: React.FC<MediaQueryProps> = (props) => {
-  const { children, ...queryParams } = props
+  const { children, matches: initialMatches, ...queryParams } = props
   const query = React.useMemo(() => createMediaQuery(queryParams), [
     queryParams,
   ])
-  const [matches, setMatches] = React.useState(false)
+  const [matches, setMatches] = React.useState(initialMatches)
 
   const handleMediaQueryChange = (
     mediaQueryList: MediaQueryList | MediaQueryListEvent,
@@ -52,6 +52,10 @@ const MediaQuery: React.FC<MediaQueryProps> = (props) => {
   }, Object.keys(queryParams))
 
   return children(matches)
+}
+
+MediaQuery.defaultProps = {
+  matches: false,
 }
 
 export default MediaQuery

--- a/src/components/Only.tsx
+++ b/src/components/Only.tsx
@@ -9,7 +9,7 @@ import mergeAreaRecords from '@utils/breakpoints/mergeAreaRecords'
 
 export type BreakpointRef = string | Breakpoint
 
-const resolveBreakpoint = (breakpointRef: BreakpointRef): Breakpoint => {
+export const resolveBreakpoint = (breakpointRef: BreakpointRef): Breakpoint => {
   return typeof breakpointRef === 'string'
     ? Layout.breakpoints[breakpointRef]
     : breakpointRef

--- a/src/components/Visible.tsx
+++ b/src/components/Visible.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+import Box from './Box'
+import { OnlyProps, resolveBreakpoint } from './Only'
+import { useMediaQuery } from '@src/hooks/useMediaQuery'
+import mergeAreaRecords from '@src/utils/breakpoints/mergeAreaRecords'
+import openBreakpoint from '@src/utils/breakpoints/openBreakpoint'
+import closeBreakpoint from '@src/utils/breakpoints/closeBreakpoint'
+
+const VisibleContainer = styled(Box)<{ matches: boolean }>`
+  ${({ matches }) =>
+    !matches &&
+    css`
+      visibility: hidden;
+    `}
+`
+
+const Visible: React.FC<OnlyProps> = ({
+  children,
+  except,
+  for: exactBreakpointName,
+  from: minBreakpointName,
+  to: maxBreakpointName,
+  ...boxProps
+}) => {
+  const exactBreakpoint = resolveBreakpoint(exactBreakpointName)
+  const minBreakpoint = resolveBreakpoint(minBreakpointName)
+  const maxBreakpoint = resolveBreakpoint(maxBreakpointName)
+
+  let mediaQuery = exactBreakpoint
+
+  // Bell, __/--\__
+  if (minBreakpoint && maxBreakpoint && !except) {
+    const { breakpoint } = mergeAreaRecords(
+      {
+        behavior: 'down',
+        breakpoint: maxBreakpoint,
+      },
+      {
+        behavior: 'up',
+        breakpoint: minBreakpoint,
+      },
+      false,
+    )
+
+    mediaQuery = breakpoint
+  }
+
+  // Notch, --\__/--
+  if (minBreakpoint && maxBreakpoint && except) {
+    mediaQuery = [closeBreakpoint(minBreakpoint), openBreakpoint(maxBreakpoint)]
+  }
+
+  // High-pass, __/--
+  if (minBreakpoint && !maxBreakpoint) {
+    mediaQuery = openBreakpoint(minBreakpoint)
+  }
+
+  // Low-pass, --\__
+  if (!minBreakpoint && maxBreakpoint) {
+    mediaQuery = closeBreakpoint(maxBreakpoint)
+  }
+
+  console.log({ mediaQuery })
+
+  const matches = useMediaQuery(mediaQuery)
+
+  return (
+    <VisibleContainer {...boxProps} matches={matches}>
+      {children}
+    </VisibleContainer>
+  )
+}
+
+export default Visible

--- a/src/components/Visible.tsx
+++ b/src/components/Visible.tsx
@@ -61,8 +61,6 @@ const Visible: React.FC<OnlyProps> = ({
     mediaQuery = closeBreakpoint(maxBreakpoint)
   }
 
-  console.log({ mediaQuery })
-
   const matches = useMediaQuery(mediaQuery)
 
   return (

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -5,6 +5,9 @@ import normalizeQuery from '@src/utils/styles/normalizeQuery'
 import transformNumeric from '@utils/math/transformNumeric'
 import compose from '@src/utils/functions/compose'
 
+/**
+ * Creates a media querty string based on the given params.
+ */
 const createMediaQuery = (queryParams: MediaQueryParams): string => {
   return compose(
     joinQueryList(([paramName, paramValue]) => {
@@ -19,6 +22,7 @@ const createMediaQuery = (queryParams: MediaQueryParams): string => {
       const resolvedParamValue = /^\d/.test(String(paramValue))
         ? transformNumeric(paramValue)
         : paramValue
+
       return `(${paramName}:${resolvedParamValue})`
     }),
     normalizeQuery,
@@ -26,7 +30,7 @@ const createMediaQuery = (queryParams: MediaQueryParams): string => {
 }
 
 type UseMediaQuery = (
-  queryParams: MediaQueryParams,
+  queryParams: MediaQueryParams[] | MediaQueryParams,
   initialMatches?: boolean,
 ) => boolean
 
@@ -36,7 +40,10 @@ export const useMediaQuery: UseMediaQuery = (
 ): boolean => {
   const [matches, setMatches] = useState(initialMatches)
   const query = useMemo(() => {
-    return createMediaQuery(queryParams)
+    return []
+      .concat(queryParams)
+      .map(createMediaQuery)
+      .join(',')
   }, [queryParams])
 
   const handleMediaQueryChange = (

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,59 @@
+import { useState, useMemo, useEffect } from 'react'
+import { MediaQuery as MediaQueryParams } from '@const/defaultOptions'
+import { joinQueryList } from '@utils/styles/createMediaQuery'
+import normalizeQuery from '@src/utils/styles/normalizeQuery'
+import transformNumeric from '@utils/math/transformNumeric'
+import compose from '@src/utils/functions/compose'
+
+const createMediaQuery = (queryParams: MediaQueryParams): string => {
+  return compose(
+    joinQueryList(([paramName, paramValue]) => {
+      /**
+       * Transform values that begin with a number to prevent
+       * transformations of "calc" expressions.
+       * Transformation of numerics is necessary when a simple
+       * number is used as a value (min-width: 750) is not valid.
+       *
+       * (min-width: 750) ==> (min-width: 750px)
+       */
+      const resolvedParamValue = /^\d/.test(String(paramValue))
+        ? transformNumeric(paramValue)
+        : paramValue
+      return `(${paramName}:${resolvedParamValue})`
+    }),
+    normalizeQuery,
+  )(queryParams)
+}
+
+type UseMediaQuery = (
+  queryParams: MediaQueryParams,
+  initialMatches?: boolean,
+) => boolean
+
+export const useMediaQuery: UseMediaQuery = (
+  queryParams,
+  initialMatches = false,
+): boolean => {
+  const [matches, setMatches] = useState(initialMatches)
+  const query = useMemo(() => {
+    return createMediaQuery(queryParams)
+  }, [queryParams])
+
+  const handleMediaQueryChange = (
+    mediaQueryList: MediaQueryList | MediaQueryListEvent,
+  ) => {
+    setMatches(mediaQueryList.matches)
+  }
+
+  useEffect(() => {
+    const mediaQueryList = matchMedia(query)
+    handleMediaQueryChange(mediaQueryList)
+    mediaQueryList.addListener(handleMediaQueryChange)
+
+    return () => {
+      mediaQueryList.removeListener(handleMediaQueryChange)
+    }
+  }, Object.keys(queryParams))
+
+  return matches
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@ export { default as defaultOptions } from '@const/defaultOptions'
 /* Components */
 export { default as Box } from '@components/Box'
 export { default as Composition } from '@components/Composition'
-export { default as Only } from '@components/Only'
 export { default as MediaQuery } from '@components/MediaQuery'
+export { default as Only } from '@components/Only'
+export { default as Visible } from '@components/Visible'
 
 /* Hooks */
 export { default as useViewportChange } from './hooks/useViewportChange'


### PR DESCRIPTION
`Visible` component behaves similar to `Only`, but instead of conditional rendering it provides conditional display of its children. Useful for SSR scenarios of dynamically present content, since `Visible` preserves the space taken by an element. Uses `visibility` CSS property to preserve the physical space occupied by the children.

## Changes

- `MediaQuery` component now respects the initial `matches` value
- Adds `useMediaQuery` hook to resolve to a `boolean` upon a media query match
- `MediaQuery` component now uses `useMediaQuery` hook

## GitHub

- Closes #134 

## Roadmap

- [x] Prepare the existing code
- [x] Implement the `Visible` component
- [x] Add test suites
