### PR TITLE
useMediaQuery: Uses "useLayoutEffect" instead of "useEffect"

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useLayoutEffect } from 'react'
 import { MediaQuery as MediaQueryParams } from '@const/defaultOptions'
 import { joinQueryList } from '@utils/styles/createMediaQuery'
 import normalizeQuery from '@src/utils/styles/normalizeQuery'
@@ -52,7 +52,7 @@ export const useMediaQuery: UseMediaQuery = (
     setMatches(mediaQueryList.matches)
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const mediaQueryList = matchMedia(query)
     handleMediaQueryChange(mediaQueryList)
     mediaQueryList.addListener(handleMediaQueryChange)


### PR DESCRIPTION
Refactors how `useMediaQuery` works so there is no stuttering during re-renders with the same media query state.

## Changes

- Uses `useLayoutEffect` instead of `useEffect` in `useMediaQuery` hook (synchronously re-renders by awaiting the DOM, meaning, `matchMedia`)

## GitHub

- Closes #234 
