### PR TITLE
useResponsiveComponent: Uses "React.forwardRef" to propagate ref

### DIFF
--- a/packages/atomic-layout/examples/hooks/UseResponsiveComponent.jsx
+++ b/packages/atomic-layout/examples/hooks/UseResponsiveComponent.jsx
@@ -9,18 +9,33 @@ const Text = useResponsiveComponent(
   `,
 )
 
-const Scenario = () => (
-  <Text
-    id="text"
-    size={16}
-    sizeMd={20}
-    sizeLg={24}
-    color="black"
-    colorSm="green"
-    colorLg="red"
-  >
-    Quick brown fox
-  </Text>
-)
+const Scenario = () => {
+  const textRef = React.useRef({})
+  const [refDerivedData, setRefDerivedData] = React.useState(null)
+
+  React.useEffect(() => {
+    setRefDerivedData(textRef.current.id)
+  }, [textRef.current])
+
+  return (
+    <div>
+      <Text
+        ref={textRef}
+        id="text"
+        size={16}
+        sizeMd={20}
+        sizeLg={24}
+        color="black"
+        colorSm="green"
+        colorLg="red"
+      >
+        Quick brown fox
+      </Text>
+      <p>
+        Ref: <span id="ref">#{refDerivedData}</span>
+      </p>
+    </div>
+  )
+}
 
 export default Scenario

--- a/packages/atomic-layout/examples/hooks/useResponsiveComponent.test.js
+++ b/packages/atomic-layout/examples/hooks/useResponsiveComponent.test.js
@@ -3,35 +3,43 @@ describe('useResponsiveComponent', () => {
     cy.loadStory(['hooks'], ['useresponsivecomponent'])
   })
 
-  it('custom responsive prop has correct initial state', () => {
-    cy.get('#text')
-      .should('have.css', 'font-size', '16px')
-      .should('have.css', 'color', 'rgb(0, 0, 0)')
-  })
-
-  it('custom responsive prop changes correctly on breakpoint changes', () => {
-    cy.setBreakpoint('sm').then(() => {
+  describe('Prmiary behavior', () => {
+    it('custom responsive prop has correct initial state', () => {
       cy.get('#text')
         .should('have.css', 'font-size', '16px')
-        .should('have.css', 'color', 'rgb(0, 128, 0)')
+        .should('have.css', 'color', 'rgb(0, 0, 0)')
     })
 
-    cy.setBreakpoint('md').then(() => {
-      cy.get('#text')
-        .should('have.css', 'font-size', '20px')
-        .should('have.css', 'color', 'rgb(0, 128, 0)')
-    })
+    it('custom responsive prop changes correctly on breakpoint changes', () => {
+      cy.setBreakpoint('sm').then(() => {
+        cy.get('#text')
+          .should('have.css', 'font-size', '16px')
+          .should('have.css', 'color', 'rgb(0, 128, 0)')
+      })
 
-    cy.setBreakpoint('lg').then(() => {
-      cy.get('#text')
-        .should('have.css', 'font-size', '24px')
-        .should('have.css', 'color', 'rgb(255, 0, 0)')
-    })
+      cy.setBreakpoint('md').then(() => {
+        cy.get('#text')
+          .should('have.css', 'font-size', '20px')
+          .should('have.css', 'color', 'rgb(0, 128, 0)')
+      })
 
-    cy.setBreakpoint('xl').then(() => {
-      cy.get('#text')
-        .should('have.css', 'font-size', '24px')
-        .should('have.css', 'color', 'rgb(255, 0, 0)')
+      cy.setBreakpoint('lg').then(() => {
+        cy.get('#text')
+          .should('have.css', 'font-size', '24px')
+          .should('have.css', 'color', 'rgb(255, 0, 0)')
+      })
+
+      cy.setBreakpoint('xl').then(() => {
+        cy.get('#text')
+          .should('have.css', 'font-size', '24px')
+          .should('have.css', 'color', 'rgb(255, 0, 0)')
+      })
+    })
+  })
+
+  describe('Generic behavior', () => {
+    it('supports ref forwarding', () => {
+      cy.get('#ref').should('have.text', '#text')
     })
   })
 })

--- a/packages/atomic-layout/src/hooks/useResponsiveComponent.tsx
+++ b/packages/atomic-layout/src/hooks/useResponsiveComponent.tsx
@@ -3,25 +3,28 @@ import { Numeric } from '@atomic-layout/core'
 import useResponsiveProps from './useResponsiveProps'
 
 /**
- * Returns a copy of the given React component
- * that supports Responsive Props API.
+ * Returns a new React component based on the given one
+ * that enables support for Responsive Props API on arbitrary props.
  */
 function useResponsiveComponent<
   OwnProps extends Record<string, any>,
-  ResponsiveProps extends Record<string, Numeric>
+  ResponsiveProps extends Record<string, Numeric>,
+  RefType = unknown
 >(
   Component: React.FC<OwnProps>,
-): React.FC<OwnProps & Partial<ResponsiveProps>> {
-  return (responsiveProps) => {
-    /**
-     * @see https://github.com/Microsoft/TypeScript/issues/29049
-     */
-    const actualProps = useResponsiveProps<typeof responsiveProps>(
-      responsiveProps,
-    ) as OwnProps & Partial<ResponsiveProps>
+): React.FC<React.PropsWithoutRef<OwnProps & Partial<ResponsiveProps>>> {
+  return React.forwardRef<RefType, OwnProps & Partial<ResponsiveProps>>(
+    (responsiveProps, ref) => {
+      /**
+       * @see https://github.com/Microsoft/TypeScript/issues/29049
+       */
+      const actualProps = useResponsiveProps<typeof responsiveProps>(
+        responsiveProps,
+      ) as OwnProps & Partial<ResponsiveProps>
 
-    return <Component {...actualProps} />
-  }
+      return <Component ref={ref} {...actualProps} />
+    },
+  )
 }
 
 export default useResponsiveComponent


### PR DESCRIPTION
## Changes

<!-- Please describe the changes introduced by your Pull request -->

- Uses `React.forwardRef()` in `useResponsiveComponent` to propagate custom refs set by the user

## GitHub

<!-- Reference GitHub issues related or affected by your Pull request -->

- Closes #263 

## Release version

<!-- Check the character of your changes -->

> Although adoption of `React.forwardRef` is a breaking change, I wouldn't release `1.0` due to that. Current state of the library implies experimental API, in terms that it may change or get deprecated even in minor releases. Once the major version is released it will be followed according to semver.

- [x] patch (internal improvements)
- [ ] minor (backward-compatible changes)
- [ ] major (breaking, backward-incompatible changes)

## Contributor's checklist

<!-- Make sure all of the below are checked -->

- [x] My branch is up-to-date with the latest `master`
- [x] I ran `yarn verify` and verified the build and tests passing
