### PR TITLE
useResponsiveProps: Resolves next props on props change

### DIFF
--- a/packages/atomic-layout/examples/hooks/UseResponsiveComponent.jsx
+++ b/packages/atomic-layout/examples/hooks/UseResponsiveComponent.jsx
@@ -11,6 +11,7 @@ const Text = useResponsiveComponent(
 
 const Scenario = () => {
   const textRef = React.useRef({})
+  const [state, setState] = React.useState('red')
   const [refDerivedData, setRefDerivedData] = React.useState(null)
 
   React.useEffect(() => {
@@ -27,13 +28,15 @@ const Scenario = () => {
         sizeLg={24}
         color="black"
         colorSm="green"
-        colorLg="red"
+        colorLg={state}
       >
-        Quick brown fox
+        <p>
+          Quick brown fox (<span id="ref">#{refDerivedData}</span>)
+        </p>
+        <button id="change-color" onClick={() => setState('violet')}>
+          Make violet
+        </button>
       </Text>
-      <p>
-        Ref: <span id="ref">#{refDerivedData}</span>
-      </p>
     </div>
   )
 }

--- a/packages/atomic-layout/examples/hooks/useResponsiveComponent.test.js
+++ b/packages/atomic-layout/examples/hooks/useResponsiveComponent.test.js
@@ -4,13 +4,13 @@ describe('useResponsiveComponent', () => {
   })
 
   describe('Prmiary behavior', () => {
-    it('custom responsive prop has correct initial state', () => {
+    it('Custom responsive prop has correct initial state', () => {
       cy.get('#text')
         .should('have.css', 'font-size', '16px')
         .should('have.css', 'color', 'rgb(0, 0, 0)')
     })
 
-    it('custom responsive prop changes correctly on breakpoint changes', () => {
+    it('Custom responsive prop changes correctly on breakpoint changes', () => {
       cy.setBreakpoint('sm').then(() => {
         cy.get('#text')
           .should('have.css', 'font-size', '16px')
@@ -38,8 +38,21 @@ describe('useResponsiveComponent', () => {
   })
 
   describe('Generic behavior', () => {
-    it('supports ref forwarding', () => {
+    it('Supports ref forwarding', () => {
       cy.get('#ref').should('have.text', '#text')
+    })
+
+    it('Re-renders on props change', () => {
+      cy.setBreakpoint('lg')
+      cy.get('#change-color').click()
+      cy.get('#text').should('have.css', 'color', 'rgb(238, 130, 238)')
+
+      // Test that the updated value persists after breakpoint change.
+      // This ensures that "useResponsiveProps" handles both direct
+      // and responsive props updates.
+      cy.setBreakpoint('md')
+      cy.setBreakpoint('lg')
+      cy.get('#text').should('have.css', 'color', 'rgb(238, 130, 238)')
     })
   })
 })

--- a/packages/atomic-layout/src/hooks/useResponsiveProps.ts
+++ b/packages/atomic-layout/src/hooks/useResponsiveProps.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Numeric,
   Layout,
@@ -15,27 +15,45 @@ const useResponsiveProps = <ResponsiveProps extends Record<string, Numeric>>(
   responsiveProps: ResponsiveProps,
 ): Partial<ResponsiveProps> => {
   const [props, setProps] = useState<ResponsiveProps>()
+  const [breakpointName, setBreakpointName] = useState<string>()
 
-  useBreakpointChange(() => {
-    const nextProps = Object.keys(responsiveProps)
+  const resolveProps = (inputProps: ResponsiveProps) => {
+    const nextProps = Object.keys(inputProps)
       .map(parsePropName)
       .filter(({ breakpoint, behavior }) => {
         const mediaQuery = createMediaQuery(
           Layout.breakpoints[breakpoint.name],
           behavior,
         )
-        return matchMedia(mediaQuery).matches
+        const { matches } = matchMedia(mediaQuery)
+
+        return matches
       })
       .reduce<ResponsiveProps>(
         (acc, { originPropName, purePropName }) => ({
           ...acc,
-          [purePropName]: responsiveProps[originPropName],
+          [purePropName]: inputProps[originPropName],
         }),
         {} as ResponsiveProps,
       )
 
+    return nextProps
+  }
+
+  // Store the current breakpoint name in the state.
+  // That way props update effect below can re-evaluate whenever
+  // a breakpoint changes.
+  // When the next prop resolver is given directly to "useBreakpointChange"
+  // it always resolves the input "responsiveProps" to their initial value.
+  // Using `useCallback()` hook doesn't help.
+  useBreakpointChange(setBreakpointName)
+
+  // Update props whenever input props change.
+  // Required to trigger re-render on props change.
+  useEffect(() => {
+    const nextProps = resolveProps(responsiveProps)
     setProps(nextProps)
-  })
+  }, [responsiveProps, breakpointName])
 
   return props || {}
 }

--- a/packages/atomic-layout/src/hooks/useResponsiveValue.ts
+++ b/packages/atomic-layout/src/hooks/useResponsiveValue.ts
@@ -11,11 +11,11 @@ const useResponsiveValue = <ValueType>(
   breakpoints: Record<string, ValueType>,
   defaultValue?: ValueType,
 ): ValueType => {
-  const [value, updateValue] = useState<ValueType>(defaultValue)
+  const [value, setValue] = useState<ValueType>(defaultValue)
 
   useBreakpointChange(() => {
     const nextValue = withBreakpoints<ValueType>(breakpoints, defaultValue)
-    updateValue(nextValue)
+    setValue(nextValue)
   })
 
   return value


### PR DESCRIPTION
## Changes

<!-- Please describe the changes introduced by your Pull request -->

- Adds `useEffect` to resolve next responsive props on input change
- Rewrites `useBreakpointChange` hook in `useResponsiveProps` to derive a state variable that holds the current breakpoint name
- Renames the state setter function in `useResponsiveValue` to `setValue`

## GitHub

<!-- Reference GitHub issues related or affected by your Pull request -->

- Closes #265 

## Release version

<!-- Check the character of your changes -->

- [x] patch (internal improvements)
- [ ] minor (backward-compatible changes)
- [ ] major (breaking, backward-incompatible changes)

## Contributor's checklist

<!-- Make sure all of the below are checked -->

- [x] My branch is up-to-date with the latest `master`
- [x] I ran `yarn verify` and verified the build and tests passing
