### PR TITLE
useResponsiveProps: Fixes default breakpoint prop value assignment

### DIFF
--- a/packages/atomic-layout-core/src/index.ts
+++ b/packages/atomic-layout-core/src/index.ts
@@ -31,7 +31,11 @@ export {
   PropAliases,
   PropAliasDeclaration,
 } from './const/propAliases'
-export { default as parsePropName } from './utils/strings/parsePropName'
+export {
+  default as parsePropName,
+  ParsedProp,
+  ParsedBreakpoint,
+} from './utils/strings/parsePropName'
 export { default as parseTemplates } from './utils/templates/parseTemplates'
 export {
   default as generateComponents,

--- a/packages/atomic-layout/package.json
+++ b/packages/atomic-layout/package.json
@@ -28,6 +28,7 @@
     "bundlesize:esm": "bundlesize -f lib/esm/index.js",
     "cypress": "cypress open --env envName=dev",
     "cypress:cli": "cypress run --spec=./examples/all.test.js --browser=chrome --env envName=ci",
+    "jest": "jest",
     "test": "yarn test:unit && yarn test:e2e",
     "test:unit": "cross-env BABEL_ENV=test jest --runInBand",
     "test:e2e": "yarn cypress:cli",

--- a/packages/atomic-layout/src/hooks/useResponsiveComponent.spec.tsx
+++ b/packages/atomic-layout/src/hooks/useResponsiveComponent.spec.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment node
+ */
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import useResponsiveComponent from './useResponsiveComponent'
+
+const Component = useResponsiveComponent((props) => {
+  return <img {...props} />
+})
+
+describe('useResponsiveComponent', () => {
+  describe('given rendered on a server', () => {
+    let html: ReturnType<typeof renderToString>
+
+    beforeAll(() => {
+      html = renderToString(
+        <Component src="image.png" altMd="Image" titleLgDown="Title" />,
+      )
+    })
+
+    it('should have responsive prop with default breakpoint', () => {
+      expect(html).toContain('src="image.png"')
+    })
+
+    it.skip('should have responsive prop with "down" behavior', () => {
+      expect(html).toContain('title="Title"')
+    })
+
+    it('should not have any responsive prop with other breakpoints', () => {
+      expect(html).not.toContain('alt')
+    })
+  })
+})

--- a/packages/atomic-layout/src/hooks/useResponsiveProps.ts
+++ b/packages/atomic-layout/src/hooks/useResponsiveProps.ts
@@ -26,6 +26,19 @@ const defaultMatcher: MatcherFunction = (parsedProp) => {
 }
 
 /**
+ * Server-side responsive props matcher.
+ * Apply props with the default breakpoint on the server.
+ * Server assumes the default breakpoint is currently present.
+ *
+ * @TODO Resolve for non-default breakpoints.
+ * @see https://github.com/kettanaito/atomic-layout/issues/284
+ */
+const serverMatcher: MatcherFunction = (parsedProp) => {
+  const { breakpoint } = parsedProp
+  return breakpoint.isDefault && typeof window === 'undefined'
+}
+
+/**
  * Filters given responsive props against the browser state.
  * Accepts an optional matcher function to operate on a server.
  */
@@ -53,9 +66,7 @@ const useResponsiveProps = <ResponsiveProps extends Record<string, Numeric>>(
   responsiveProps: ResponsiveProps,
 ): Partial<ResponsiveProps> => {
   const [props, setProps] = useState<ResponsiveProps>(
-    filterProps(responsiveProps, ({ breakpoint }) => {
-      return breakpoint.isDefault && typeof window === 'undefined'
-    }),
+    filterProps(responsiveProps, serverMatcher),
   )
   const [breakpointName, setBreakpointName] = useState<string>()
 

--- a/packages/atomic-layout/tslint.json
+++ b/packages/atomic-layout/tslint.json
@@ -2,6 +2,7 @@
   "extends": ["tslint-react", "../../tslint.json"],
   "rules": {
     "no-console": true,
+    "no-submodule-imports": false,
     "jsx-boolean-value": ["never"],
     "jsx-no-multiline-js": false,
     "jsx-wrap-multiline": false


### PR DESCRIPTION
## Changes

<!-- Please describe the changes introduced by your Pull request -->

- Assigns proper initial value for the state in `useResponsiveProps`

When rendered on a server no React hooks are run. The `useEffect` hook in `useResponsiveProps` is no exception, and this results into server-side markup containing no props at all, because the initial state of the respective `useState` hook is undefined. To prevent this, I make the filtering function parametric and call it with a server-side-like matcher as the initial value of the `useState` hook.

- Adds a unit test for `useResponsiveComponent` function

## GitHub

<!-- Reference GitHub issues related or affected by your Pull request -->

- Closes #272 

## Release version

<!-- Check the character of your changes -->

- [x] patch (internal improvements)
- [ ] minor (backward-compatible changes)
- [ ] major (breaking, backward-incompatible changes)

## Contributor's checklist

<!-- Make sure all of the below are checked -->

- [ ] My branch is up-to-date with the latest `master`
- [ ] I ran `yarn verify` and verified the build and tests passing
- [x] Decide on the "down" behavior matching (https://github.com/kettanaito/atomic-layout/issues/284)
