### PR TITLE
Does not generate React component for a dot placeholder

### DIFF
--- a/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.spec.ts
+++ b/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.spec.ts
@@ -16,7 +16,24 @@ describe('isAreaName', () => {
 
   describe('given a reserved keyword', () => {
     it('should return false', () => {
+      expect(isAreaName('/')).toBe(false)
       expect(isAreaName('auto')).toBe(false)
+    })
+  })
+
+  describe('given a dot placeholder', () => {
+    describe('given a single dot character', () => {
+      it('should return false', () => {
+        expect(isAreaName('.')).toBe(false)
+      })
+    })
+
+    describe('given a sequence of dots', () => {
+      it('should return false', () => {
+        expect(isAreaName('..')).toBe(false)
+        expect(isAreaName('....')).toBe(false)
+        expect(isAreaName('.......')).toBe(false)
+      })
     })
   })
 })

--- a/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.ts
+++ b/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.ts
@@ -1,4 +1,7 @@
 export const keywords = [
+  // Dot symbol (and its sequence) is a valid placeholder,
+  // but not a valid CSS Grid area name.
+  /\.+/,
   // Numbers may be present in `grid-template` definition
   // and describe dimensions of rows/columns.
   /^[0-9]/,
@@ -15,11 +18,8 @@ export const keywords = [
  * Takes into account row/column dimensions and reserved
  * keywords used in the `grid-template` definition.
  */
-export default function isAreaName(
-  areaName: string,
-  tolerateDots?: boolean,
-): boolean {
-  return keywords.concat(tolerateDots ? [] : /\.+/).every((keyword) => {
+export default function isAreaName(areaName: string): boolean {
+  return keywords.every((keyword) => {
     return keyword instanceof RegExp
       ? !keyword.test(areaName)
       : areaName !== keyword

--- a/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.ts
+++ b/packages/atomic-layout-core/src/utils/strings/isAreaName/isAreaName.ts
@@ -1,10 +1,27 @@
-const keywords = ['/', 'auto']
+export const keywords = [
+  // Numbers may be present in `grid-template` definition
+  // and describe dimensions of rows/columns.
+  /^[0-9]/,
+  // Slash is a special symbol used to declare dimensions
+  // for columns.
+  '/',
+  // "auto" is a reserved keyword to describe an automatic
+  // dimension value when sizing rows/columns.
+  'auto',
+]
 
-// Determines if the given string is a valid area name.
-// Takes into account on the row/column dimensions and
-// keywords in the "grid-template" definition.
-export default function isAreaName(areaName: string): boolean {
-  const startsWithNumber = /^[0-9]/.test(areaName)
-  const isKeyword = keywords.includes(areaName)
-  return !startsWithNumber && !isKeyword
+/**
+ * Determines if a given string is a valid CSS Grid area name.
+ * Takes into account row/column dimensions and reserved
+ * keywords used in the `grid-template` definition.
+ */
+export default function isAreaName(
+  areaName: string,
+  tolerateDots?: boolean,
+): boolean {
+  return keywords.concat(tolerateDots ? [] : /\.+/).every((keyword) => {
+    return keyword instanceof RegExp
+      ? !keyword.test(areaName)
+      : areaName !== keyword
+  })
 }

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.spec.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.spec.ts
@@ -32,4 +32,12 @@ describe('sanitizeTemplateArea', () => {
       )
     })
   })
+
+  describe('given a template string with placeholder dots', () => {
+    it('should return a parsed template string including dots', () => {
+      expect(sanitizeTemplateArea('first . second ... third')).toEqual(
+        `'first . second ... third'`,
+      )
+    })
+  })
 })

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.ts
@@ -3,30 +3,37 @@ import isAreaName from '../isAreaName'
 
 type SanitizeTemplateArea = (str: string) => string
 
-// Joins a given template string fragments into a valid template string.
-// Takes into account proper single quote wrapping around the areas
-// and no single quotes around the dimensions (row/columns).
+/**
+ * Joins a given template string fragments into a valid template string.
+ * Appends any row/column dimensions after the enclosing single quote
+ * character to have a valid `grid-template` syntax.
+ */
 const joinTemplateFragments = (fragments: string[]): string => {
   const areas: string[] = []
   const suffixes: string[] = []
 
   fragments.forEach((areaName) => {
-    if (isAreaName(areaName)) {
+    if (isAreaName(areaName, true)) {
       areas.push(areaName)
     } else {
       suffixes.push(areaName)
     }
   })
 
+  // Wraps areas string in single quote per CSS spec
   const joinedAreas = areas.length > 0 ? `'${areas.join(' ')}'` : ''
   const joinedSuffixes = suffixes.join(' ')
 
+  // Ensures row/column dimensions follow areas list after its been
+  // wrapped in single quotes.
   return [joinedAreas, joinedSuffixes].filter(Boolean).join(' ')
 }
 
-// Prepares given "grid-template-areas" string to be digestible.
-// Trims whitespace, deduplicates single quotes and wraps
-// each line in single quotes.
+/**
+ * Sanitizes a given `grid-template-areas` string.
+ * Trims whitespaces, deduplicates quotes and wraps each line
+ * in single quotes to be CSS-compliant.
+ */
 const sanitizeTemplateArea: SanitizeTemplateArea = compose(
   joinTemplateFragments,
   (area: string): string[] => area.split(' '),

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateArea/sanitizeTemplateArea.ts
@@ -13,7 +13,7 @@ const joinTemplateFragments = (fragments: string[]): string => {
   const suffixes: string[] = []
 
   fragments.forEach((areaName) => {
-    if (isAreaName(areaName, true)) {
+    if (isAreaName(areaName) || /\.+/.test(areaName)) {
       areas.push(areaName)
     } else {
       suffixes.push(areaName)

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.spec.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.spec.ts
@@ -42,6 +42,7 @@ second third
       expect(areas).toEqual(['first', 'second', 'third'])
     })
   })
+
   describe('given a template string written in "grid-template" syntax', () => {
     let areas: string[]
 
@@ -65,6 +66,28 @@ second third
       expect(areas).toContain('aside')
       expect(areas).toContain('content')
       expect(areas).toContain('header')
+    })
+  })
+
+  describe('given a template string with placeholder dots', () => {
+    let areas: string[]
+
+    beforeAll(() => {
+      areas = sanitizeTemplateString(`
+        first . second
+        third fourth .
+      `)
+    })
+
+    it('should contain list of areas names', () => {
+      expect(areas).toContain('first')
+      expect(areas).toContain('second')
+      expect(areas).toContain('third')
+      expect(areas).toContain('fourth')
+    })
+
+    it('should not any contain placeholder characters', () => {
+      expect(areas).not.toContain('.')
     })
   })
 })

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.ts
@@ -3,8 +3,11 @@ import isAreaName from '../isAreaName'
 
 type SanitizeTemplateString = (str: string) => string[]
 
-// Returns an array of unique normalized grid areas
-// from the given template string.
+/**
+ * Returns an array of unique normalized grid area names
+ * from the given template string. Any member of the returned list
+ * is later evolved into a React component.
+ */
 const sanitizeTemplateString: SanitizeTemplateString = compose(
   (list: string[]): string[] => list.sort(),
 
@@ -12,7 +15,7 @@ const sanitizeTemplateString: SanitizeTemplateString = compose(
   (list: string[]): string[] => Array.from(new Set(list)),
 
   // Filter out "template" row/columns sizes
-  (arr: string[]): string[] => arr.filter(isAreaName),
+  (arr: string[]): string[] => arr.filter((areaName) => isAreaName(areaName)),
 
   // Filter out empty area strings
   (arr: string[]): string[] => arr.filter(Boolean),

--- a/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.ts
+++ b/packages/atomic-layout-core/src/utils/strings/sanitizeTemplateString/sanitizeTemplateString.ts
@@ -15,7 +15,7 @@ const sanitizeTemplateString: SanitizeTemplateString = compose(
   (list: string[]): string[] => Array.from(new Set(list)),
 
   // Filter out "template" row/columns sizes
-  (arr: string[]): string[] => arr.filter((areaName) => isAreaName(areaName)),
+  (arr: string[]): string[] => arr.filter(isAreaName),
 
   // Filter out empty area strings
   (arr: string[]): string[] => arr.filter(Boolean),


### PR DESCRIPTION
## Changes

<!-- Please describe the changes introduced by your Pull request -->

- `isAreaName` now accepts an optional `tolerateDots` parameter to control whether a dot symbol must be considered an area name
- Adds unit tests that cover a proper dot placeholder handling

There are two functions that use `isAreaName`, but they use it for different purpose:

- `sanitizeTemplateArea` puts all areas in single quotes and all non-areas array members into dimensional suffixes that follow after the areas were wrapped in single quotes. That is to have a valid `grid-template` syntax:

```css
.composition {
  grid-template: 
    /* Note that row's dimension is outside of single quotes */
    'first . second' 150px
}
```

- `sanitizeTemplateString` accepts a list of area names and returns a list where all members should be converted into React components. That's where the issue originates, as dot was considered an area name by `isAreaName` previously.

Taken that into account, `.` (dot) should be considered an area (in order to be included the area definition string that's wrapped in single quotes) and not considered an area (when generating React components).

## GitHub

<!-- Reference GitHub issues related or affected by your Pull request -->

- Closes #287 

## Release version

<!-- Check the character of your changes -->

- [x] patch (internal improvements)
- [ ] minor (backward-compatible changes)
- [ ] major (breaking, backward-incompatible changes)

## Contributor's checklist

<!-- Make sure all of the below are checked -->

- [x] My branch is up-to-date with the latest `master`
- [x] I ran `yarn verify` and verified the build and tests passing
