### PR TITLE
useMediaQuery: Uses "useEffect" on the server

### DIFF
--- a/packages/atomic-layout/src/hooks/useMediaQuery.ts
+++ b/packages/atomic-layout/src/hooks/useMediaQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useLayoutEffect } from 'react'
+import { useState, useMemo, useEffect, useLayoutEffect } from 'react'
 import {
   MediaQuery as MediaQueryParams,
   compose,
@@ -40,6 +40,8 @@ export const useMediaQuery: UseMediaQuery = (
   queryParams,
   initialMatches = false,
 ): boolean => {
+  const useSafeEffect =
+    typeof window === 'undefined' ? useEffect : useLayoutEffect
   const [matches, setMatches] = useState(initialMatches)
   const query = useMemo(() => {
     return []
@@ -54,7 +56,7 @@ export const useMediaQuery: UseMediaQuery = (
     setMatches(mediaQueryList.matches)
   }
 
-  useLayoutEffect(() => {
+  useSafeEffect(() => {
     const mediaQueryList = matchMedia(query)
     handleMediaQueryChange(mediaQueryList)
     mediaQueryList.addListener(handleMediaQueryChange)


### PR DESCRIPTION
## Changes

<!-- Please describe the changes introduced by your Pull request -->

- Conditionally decides which hook to use (`useEffect`/`useLayoutEffect`) depending on the environment: `useEffect` is used on the server, `useLayoutEffect` on the client (see #254)

## GitHub

<!-- Reference GitHub issues related or affected by your Pull request -->

- Closes #293 

## Release version

<!-- Check the character of your changes -->

- [x] patch (internal improvements)
- [ ] minor (backward-compatible changes)
- [ ] major (breaking, backward-incompatible changes)

## Contributor's checklist

<!-- Make sure all of the below are checked -->

- [x] My branch is up-to-date with the latest `master`
- [x] I ran `yarn verify` and verified the build and tests passing
