### PR TITLE
Adds "order" CSS property support 

### DIFF
--- a/packages/atomic-layout-core/src/const/propAliases.ts
+++ b/packages/atomic-layout-core/src/const/propAliases.ts
@@ -100,6 +100,9 @@ const propAliases: PropAliases = {
   autoFlow: {
     props: ['grid-auto-flow'],
   },
+  order: {
+    props: ['order'],
+  },
   align: {
     props: ['align-self'],
   },

--- a/packages/atomic-layout-core/src/const/props.ts
+++ b/packages/atomic-layout-core/src/const/props.ts
@@ -73,6 +73,12 @@ export interface GenericProps {
    */
   flexWrap?: string
   /**
+   * Order to lay out an item in a flex or grid container.
+   * @css `order`
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/order
+   */
+  order?: number | CSSGlobalValues
+  /**
    * Aligns flex items of the current flex.
    * @css `align-self`
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/align-self

--- a/packages/atomic-layout/examples/all.test.js
+++ b/packages/atomic-layout/examples/all.test.js
@@ -20,6 +20,7 @@ describe('Components', () => {
       require('./components/Composition/declaration/TemplatePeriod.test')
       require('./components/Composition/declaration/Templateless.test')
       require('./components/Composition/declaration/GridTemplate.test')
+      require('./components/Composition/declaration/OrderProp.test')
     })
 
     describe('Rendering', () => {

--- a/packages/atomic-layout/examples/components/Composition/declaration/OrderProp.jsx
+++ b/packages/atomic-layout/examples/components/Composition/declaration/OrderProp.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Composition, Box } from 'atomic-layout'
+import Square from '@stories/Square'
+
+const OrderPropExample = () => {
+  return (
+    <>
+      <h2>Template-less composition</h2>
+      <p>
+        Template-less Composition should respect a custom <code>order</code>{' '}
+        prop of its children.
+      </p>
+      <Composition id="template-less-composition" gap={10}>
+        <Box as={Square} id="box-first">
+          First
+        </Box>
+        <Box as={Square} id="box-second">
+          Second
+        </Box>
+        <Box as={Square} id="box-third" order={-1}>
+          Third
+        </Box>
+      </Composition>
+
+      <h2>Regular composition</h2>
+      <p>
+        When given explicit <code>areas</code>/<code>template</code> prop,
+        Composition should ignore any given <code>order</code> prop on its
+        children areas, and always render according to the template.
+      </p>
+      <Composition id="regular-composition" areas="left center right" gap={10}>
+        {(Areas) => (
+          <>
+            <Areas.Left data-area="left">
+              <Square>Left</Square>
+            </Areas.Left>
+            <Areas.Center data-area="center">
+              <Square>Center</Square>
+            </Areas.Center>
+            <Areas.Right data-area="right" order={-1}>
+              <Square>Right</Square>
+            </Areas.Right>
+          </>
+        )}
+      </Composition>
+    </>
+  )
+}
+
+export default OrderPropExample

--- a/packages/atomic-layout/examples/components/Composition/declaration/OrderProp.test.js
+++ b/packages/atomic-layout/examples/components/Composition/declaration/OrderProp.test.js
@@ -1,0 +1,41 @@
+const { expect } = require('chai')
+
+describe('Order prop', function() {
+  before(() => {
+    cy.loadStory(['components', 'composition', 'declaration'], ['order-prop'])
+  })
+
+  describe('given template-less composition', () => {
+    it('should render the child with negative order first', () => {
+      cy.get('#box-third').then(([thirdElement]) => {
+        cy.get('#box-first').then(([firstElement]) => {
+          expect(thirdElement.offsetTop).to.be.lessThan(firstElement.offsetTop)
+        })
+      })
+    })
+
+    it('should render other children as-is', () => {
+      cy.get('#box-first').then(([firstElement]) => {
+        cy.get('#box-second').then(([secondElement]) => {
+          expect(firstElement.offsetTop).to.be.lessThan(secondElement.offsetTop)
+        })
+      })
+    })
+  })
+
+  describe('given composition with a template', () => {
+    it('should ignore the "order" prop on area component', () => {
+      cy.get('[data-area="right"]').then(([rightElement]) => {
+        cy.get('[data-area="left"]').then(([leftElement]) => {
+          expect(rightElement.offsetLeft).to.be.greaterThan(
+            leftElement.offsetLeft,
+          )
+        })
+      })
+    })
+
+    it('should render areas according to the template', () => {
+      cy.get('#regular-composition').assertAreas([['left', 'center', 'right']])
+    })
+  })
+})

--- a/packages/atomic-layout/examples/index.js
+++ b/packages/atomic-layout/examples/index.js
@@ -33,11 +33,13 @@ import TemplateIndentation from './components/Composition/declaration/TemplateIn
 import Templateless from './components/Composition/declaration/Templateless'
 import TemplatePeriod from './components/Composition/declaration/TemplatePeriod'
 import GridTemplate from './components/Composition/declaration/GridTemplate'
+import CompositionOrderProp from './components/Composition/declaration/OrderProp'
 storiesOf('Components|Composition/Declaration', module)
   .add('Template indentation', TemplateIndentation)
   .add('Template-less composition', Templateless)
   .add('Template period', TemplatePeriod)
   .add('Grid template syntax', GridTemplate)
+  .add('Order prop', CompositionOrderProp)
 
 import WeakArea from './components/Composition/rendering/WeakArea'
 import NamespaceCollision from './components/Composition/rendering/NamespaceCollision'


### PR DESCRIPTION
## Changes

<!-- Describe the changes introduced by this Pull request -->

- Adds `order` CSS property support to `GenericProps` interface to be used on `Box` and Composition's areas components

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Closes #295 

## Release version

<!-- Check the character of your changes -->

- [ ] internal (no release required)
- [ ] patch (bug fixes)
- [x] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [ ] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [ ] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->
