### PR TITLE
Supports refs forwarding for exported components

### DIFF
--- a/packages/atomic-layout-emotion/test/refs.spec.tsx
+++ b/packages/atomic-layout-emotion/test/refs.spec.tsx
@@ -1,0 +1,4 @@
+import { Box, Composition, Only, Visible } from '../src'
+import { createForwardRefTest } from '../../atomic-layout/test/createForwardRefTest'
+
+createForwardRefTest({ Box, Composition, Only, Visible })

--- a/packages/atomic-layout/src/components/Composition.tsx
+++ b/packages/atomic-layout/src/components/Composition.tsx
@@ -26,40 +26,39 @@ const createAreaComponent = (areaName: string): AreaComponent => (
   return <Box area={areaName} {...props} />
 }
 
-const Composition: React.FC<CompositionProps> = ({
-  children,
-  ...restProps
-}) => {
-  const areasList = parseTemplates(restProps)
+const Composition = React.forwardRef<unknown, CompositionProps>(
+  ({ children, ...restProps }, ref) => {
+    const areasList = parseTemplates(restProps)
 
-  // Memoize areas generation so parental updates do not re-generate areas,
-  // making area components preserve their internal state.
-  const Areas = React.useMemo(() => {
-    return generateComponents(areasList, createAreaComponent, withPlaceholder)
-  }, [areasList])
+    // Memoize areas generation so parental updates do not re-generate areas,
+    // making area components preserve their internal state.
+    const Areas = React.useMemo(() => {
+      return generateComponents(areasList, createAreaComponent, withPlaceholder)
+    }, [areasList])
 
-  const hasAreaComponents = Object.keys(Areas).length > 0
-  const childrenType = typeof children
-  const hasChildrenFunction = childrenType === 'function'
+    const hasAreaComponents = Object.keys(Areas).length > 0
+    const childrenType = typeof children
+    const hasChildrenFunction = childrenType === 'function'
 
-  // Warn when provided "areas"/"template" props, but didn't use a render prop pattern.
-  warn(
-    !(hasAreaComponents && !hasChildrenFunction),
-    `Failed to render Composition with template areas ["${Object.keys(
-      Areas,
-    ).join(
-      '", "',
-    )}"]: expected children to be a function, but got: ${childrenType}. Please provide render function as children, or remove assigned template props (\`areas\`/\`template\`).`,
-  )
+    // Warn when provided "areas"/"template" props, but didn't use a render prop pattern.
+    warn(
+      !(hasAreaComponents && !hasChildrenFunction),
+      `Failed to render 'Composition' with template areas ["${Object.keys(
+        Areas,
+      ).join(
+        '", "',
+      )}"]: expected children to be a function, but got: ${childrenType}. Please provide render function as children, or remove assigned template props (\`areas\`/\`template\`).`,
+    )
 
-  return (
-    <CompositionWrapper {...restProps}>
-      {hasAreaComponents && hasChildrenFunction
-        ? (children as CompositionRenderProp)(Areas)
-        : children}
-    </CompositionWrapper>
-  )
-}
+    return (
+      <CompositionWrapper ref={ref} {...restProps}>
+        {hasAreaComponents && hasChildrenFunction
+          ? (children as CompositionRenderProp)(Areas)
+          : children}
+      </CompositionWrapper>
+    )
+  },
+)
 
 Composition.displayName = 'Composition'
 

--- a/packages/atomic-layout/src/components/Composition.tsx
+++ b/packages/atomic-layout/src/components/Composition.tsx
@@ -12,6 +12,7 @@ import {
 } from '@atomic-layout/core'
 import Box from './Box'
 import { withPlaceholder } from '../utils/withPlaceholder'
+import { forwardRef } from '../utils/forwardRef'
 
 const CompositionWrapper = styled.div<CompositionProps>`
   && {
@@ -20,13 +21,12 @@ const CompositionWrapper = styled.div<CompositionProps>`
   }
 `
 
-const createAreaComponent = (areaName: string): AreaComponent => (
-  props: BoxProps,
-) => {
-  return <Box area={areaName} {...props} />
-}
+const createAreaComponent = (areaName: string): AreaComponent =>
+  forwardRef((props: BoxProps, ref) => {
+    return <Box ref={ref} area={areaName} {...props} />
+  })
 
-const Composition = React.forwardRef<unknown, CompositionProps>(
+const Composition = forwardRef<unknown, CompositionProps>(
   ({ children, ...restProps }, ref) => {
     const areasList = parseTemplates(restProps)
 

--- a/packages/atomic-layout/src/components/Only.tsx
+++ b/packages/atomic-layout/src/components/Only.tsx
@@ -4,10 +4,11 @@ import Box from './Box'
 import useResponsiveQuery, {
   ResponsiveQueryParams,
 } from '../hooks/useResponsiveQuery'
+import { forwardRef } from '../utils/forwardRef'
 
 export type OnlyProps = BoxProps & ResponsiveQueryParams
 
-const Only = React.forwardRef<unknown, OnlyProps>(
+const Only = forwardRef<unknown, OnlyProps>(
   ({ children, except, for: exactBreakpoint, from, to, ...restProps }, ref) => {
     const matches = useResponsiveQuery({
       for: exactBreakpoint,
@@ -15,6 +16,7 @@ const Only = React.forwardRef<unknown, OnlyProps>(
       to,
       except,
     })
+
     return (
       matches && (
         <Box ref={ref} {...restProps}>

--- a/packages/atomic-layout/src/components/Only.tsx
+++ b/packages/atomic-layout/src/components/Only.tsx
@@ -7,17 +7,23 @@ import useResponsiveQuery, {
 
 export type OnlyProps = BoxProps & ResponsiveQueryParams
 
-const Only: React.FC<OnlyProps> = ({
-  children,
-  except,
-  for: exactBreakpoint,
-  from,
-  to,
-  ...restProps
-}) => {
-  const matches = useResponsiveQuery({ for: exactBreakpoint, from, to, except })
-  return matches && <Box {...restProps}>{children}</Box>
-}
+const Only = React.forwardRef<unknown, OnlyProps>(
+  ({ children, except, for: exactBreakpoint, from, to, ...restProps }, ref) => {
+    const matches = useResponsiveQuery({
+      for: exactBreakpoint,
+      from,
+      to,
+      except,
+    })
+    return (
+      matches && (
+        <Box ref={ref} {...restProps}>
+          {children}
+        </Box>
+      )
+    )
+  },
+)
 
 Only.displayName = 'Only'
 

--- a/packages/atomic-layout/src/components/Visible.tsx
+++ b/packages/atomic-layout/src/components/Visible.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import Box from './Box'
 import { OnlyProps } from './Only'
 import useResponsiveQuery from '../hooks/useResponsiveQuery'
+import { forwardRef } from '../utils/forwardRef'
 
 const VisibleContainer = styled(Box)<{ matches: boolean }>`
   ${({ matches }) =>
@@ -12,10 +13,7 @@ const VisibleContainer = styled(Box)<{ matches: boolean }>`
     `}
 `
 
-/**
- * Displays children when the given responsive query matches.
- */
-const Visible = React.forwardRef<unknown, OnlyProps>(
+const Visible = forwardRef<unknown, OnlyProps>(
   (
     { children, except, for: exactBreakpointName, from, to, ...boxProps },
     ref,

--- a/packages/atomic-layout/src/components/Visible.tsx
+++ b/packages/atomic-layout/src/components/Visible.tsx
@@ -15,28 +15,31 @@ const VisibleContainer = styled(Box)<{ matches: boolean }>`
 /**
  * Displays children when the given responsive query matches.
  */
-const Visible: React.FC<OnlyProps> = ({
-  children,
-  except,
-  for: exactBreakpointName,
-  from,
-  to,
-  ...boxProps
-}) => {
-  const matches = useResponsiveQuery({
-    except,
-    for: exactBreakpointName,
-    from,
-    to,
-  })
-  const ariaAttributes = !matches ? { 'aria-hidden': 'true' } : {}
+const Visible = React.forwardRef<unknown, OnlyProps>(
+  (
+    { children, except, for: exactBreakpointName, from, to, ...boxProps },
+    ref,
+  ) => {
+    const matches = useResponsiveQuery({
+      except,
+      for: exactBreakpointName,
+      from,
+      to,
+    })
+    const ariaAttributes = !matches ? { 'aria-hidden': 'true' } : {}
 
-  return (
-    <VisibleContainer {...boxProps} {...ariaAttributes} matches={matches}>
-      {children}
-    </VisibleContainer>
-  )
-}
+    return (
+      <VisibleContainer
+        ref={ref}
+        {...boxProps}
+        {...ariaAttributes}
+        matches={matches}
+      >
+        {children}
+      </VisibleContainer>
+    )
+  },
+)
 
 Visible.displayName = 'Visible'
 

--- a/packages/atomic-layout/src/utils/forwardRef.ts
+++ b/packages/atomic-layout/src/utils/forwardRef.ts
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+export const forwardRef = <RefType, Props>(
+  component: React.RefForwardingComponent<RefType, Props>,
+): React.FC<Props & { ref?: RefType }> => {
+  return React.forwardRef<RefType, any>(component)
+}

--- a/packages/atomic-layout/src/utils/withPlaceholder.tsx
+++ b/packages/atomic-layout/src/utils/withPlaceholder.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Breakpoint, AreaComponent, GenericProps } from '@atomic-layout/core'
+import { forwardRef } from './forwardRef'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 
 /**
@@ -11,19 +12,18 @@ export const withPlaceholder = (
   Component: AreaComponent,
   breakpoints: Breakpoint[],
 ) => {
-  const Placeholder: React.FC<GenericProps> = React.forwardRef<
-    unknown,
-    React.PropsWithChildren<GenericProps>
-  >(({ children, ...restProps }, ref) => {
-    const matches = useMediaQuery(breakpoints)
-    return (
-      matches && (
-        <Component ref={ref} {...restProps}>
-          {children}
-        </Component>
+  const Placeholder = forwardRef<unknown, GenericProps>(
+    ({ children, ...restProps }, ref) => {
+      const matches = useMediaQuery(breakpoints)
+      return (
+        matches && (
+          <Component ref={ref} {...restProps}>
+            {children}
+          </Component>
+        )
       )
-    )
-  })
+    },
+  )
 
   Placeholder.displayName = `Placeholder(${Component.displayName})`
 

--- a/packages/atomic-layout/src/utils/withPlaceholder.tsx
+++ b/packages/atomic-layout/src/utils/withPlaceholder.tsx
@@ -11,10 +11,19 @@ export const withPlaceholder = (
   Component: AreaComponent,
   breakpoints: Breakpoint[],
 ) => {
-  const Placeholder: React.FC<GenericProps> = ({ children, ...restProps }) => {
+  const Placeholder: React.FC<GenericProps> = React.forwardRef<
+    unknown,
+    React.PropsWithChildren<GenericProps>
+  >(({ children, ...restProps }, ref) => {
     const matches = useMediaQuery(breakpoints)
-    return matches && <Component {...restProps}>{children}</Component>
-  }
+    return (
+      matches && (
+        <Component ref={ref} {...restProps}>
+          {children}
+        </Component>
+      )
+    )
+  })
 
   Placeholder.displayName = `Placeholder(${Component.displayName})`
 

--- a/packages/atomic-layout/test/createForwardRefTest.tsx
+++ b/packages/atomic-layout/test/createForwardRefTest.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import '../../atomic-layout-core/src/utils/breakpoints/withBreakpoints/matchMedia.mock'
+import { render } from '@testing-library/react'
+
+interface ComponentsMap {
+  Box: any
+  Composition: any
+  Only: any
+  Visible: any
+}
+
+export const createForwardRefTest = (components: ComponentsMap) => {
+  const { Box, Composition, Only, Visible } = components
+
+  describe('Refs', () => {
+    it('Box', () => {
+      const ref = React.createRef()
+      render(<Box ref={ref} />)
+      expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    })
+
+    it('Composition', () => {
+      const ref = React.createRef()
+      render(<Composition ref={ref} as="span" />)
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement)
+    })
+
+    it('Only', () => {
+      const ref = React.createRef()
+      render(<Only ref={ref} from="md" />)
+      expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    })
+
+    it('Visible', () => {
+      const ref = React.createRef()
+      render(<Visible ref={ref} as="span" from="md" />)
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement)
+    })
+  })
+}

--- a/packages/atomic-layout/test/createForwardRefTest.tsx
+++ b/packages/atomic-layout/test/createForwardRefTest.tsx
@@ -1,37 +1,66 @@
 import React from 'react'
-import '../../atomic-layout-core/src/utils/breakpoints/withBreakpoints/matchMedia.mock'
 import { render } from '@testing-library/react'
+import '../../atomic-layout-core/src/utils/breakpoints/withBreakpoints/matchMedia.mock'
+import {
+  Box as DefaultBox,
+  Composition as DefaultComposition,
+  Only as DefaultOnly,
+  Visible as DefaultVisible,
+} from '../src/'
 
 interface ComponentsMap {
-  Box: any
-  Composition: any
-  Only: any
-  Visible: any
+  Box: typeof DefaultBox
+  Composition: typeof DefaultComposition
+  Only: typeof DefaultOnly
+  Visible: typeof DefaultVisible
 }
 
 export const createForwardRefTest = (components: ComponentsMap) => {
   const { Box, Composition, Only, Visible } = components
 
   describe('Refs', () => {
-    it('Box', () => {
+    it('Supports ref forwarding for the "Box" component', () => {
       const ref = React.createRef()
       render(<Box ref={ref} />)
       expect(ref.current).toBeInstanceOf(HTMLDivElement)
     })
 
-    it('Composition', () => {
+    it('Supports ref forwarding for the "Composition" component', () => {
       const ref = React.createRef()
-      render(<Composition ref={ref} as="span" />)
+      render(
+        <Composition ref={ref} as="span">
+          <p>Arbitrary content</p>
+        </Composition>,
+      )
       expect(ref.current).toBeInstanceOf(HTMLSpanElement)
     })
 
-    it('Only', () => {
+    it('Supports ref forwarding for the generated Area components', () => {
+      const leftRef = React.createRef()
+      const rightRef = React.createRef()
+      render(
+        <Composition areas="left right">
+          {(Areas) => (
+            <>
+              <Areas.Left ref={leftRef}>Left</Areas.Left>
+              <Areas.Right ref={rightRef} as="span">
+                Right
+              </Areas.Right>
+            </>
+          )}
+        </Composition>,
+      )
+      expect(leftRef.current).toBeInstanceOf(HTMLDivElement)
+      expect(rightRef.current).toBeInstanceOf(HTMLSpanElement)
+    })
+
+    it('Supports ref forwarding for the "Only" component', () => {
       const ref = React.createRef()
       render(<Only ref={ref} from="md" />)
       expect(ref.current).toBeInstanceOf(HTMLDivElement)
     })
 
-    it('Visible', () => {
+    it('Supports ref forwarding for the "Visible" component', () => {
       const ref = React.createRef()
       render(<Visible ref={ref} as="span" from="md" />)
       expect(ref.current).toBeInstanceOf(HTMLSpanElement)

--- a/packages/atomic-layout/test/refs.spec.tsx
+++ b/packages/atomic-layout/test/refs.spec.tsx
@@ -1,0 +1,9 @@
+import { Box, Composition, Only, Visible } from '../src'
+import { createForwardRefTest } from './createForwardRefTest'
+
+createForwardRefTest({
+  Box,
+  Composition,
+  Only,
+  Visible,
+})


### PR DESCRIPTION
## Changes

<!-- Describe the changes introduced by this Pull request -->

- Wraps `Composition`, `Only` and `Visible` in `React.forwardRef()`
- `Box` forwards refs automatically, because it's a styled component

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Closes #297

## Release version

<!-- Check the character of your changes -->

> It's recommended that the introduction of `forwardRef()` is accompanied by the major version bump. However, since Atomic Layout has not reached the first major version release, these changes won't be released under the major version.

- [ ] internal (no release required)
- [ ] patch (bug fixes)
- [x] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [x] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [x] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->

- [x] Fix affected components losing their props signature (results into wrong type validation and broken CI)
- [x] Check that all components, including generated Area components, respect their props types
- [x] ~~Update docs on instructions about ref forwarding~~