### PR TITLE
Adds meaningful "displayName" to exported components

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -118,11 +118,13 @@ import IterativeAreas from './recipes/IterativeAreas'
 storiesOf('Recipes|All', module).add('Iterative areas', IterativeAreas)
 
 /**
- * Bugfixes
+ * Regression
  */
+import DisplayNames from './regression/DisplayNames'
 import StylesUndefined from './regression/StylesUndefined'
 import SingleResponsiveProp from './regression/SingleResponsiveProp'
 
 storiesOf('Regression|All', module)
+  .add('Display names', DisplayNames)
   .add('Styles undefined', StylesUndefined)
   .add('Single responsive prop', SingleResponsiveProp)

--- a/examples/regression/DisplayNames.jsx
+++ b/examples/regression/DisplayNames.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Box, Composition, Only, Visible, MediaQuery } from 'atomic-layout'
+
+const DisplayNames = () => (
+  <div>
+    <Box id="box">{Box.displayName}</Box>
+    <Composition
+      id="composition"
+      areas="one"
+      data-display-name={Composition.displayName}
+    >
+      {(Areas) => (
+        <Areas.One id="composition-area">{Areas.One.displayName}</Areas.One>
+      )}
+    </Composition>
+    <Only id="only" from="xs">
+      {Only.displayName}
+    </Only>
+    <Visible id="visible" from="xs">
+      {Visible.displayName}
+    </Visible>
+    <MediaQuery matches={true}>
+      {() => <p id="media-query">{MediaQuery.displayName}</p>}
+    </MediaQuery>
+  </div>
+)
+
+export default DisplayNames

--- a/examples/regression/DisplayNames.test.js
+++ b/examples/regression/DisplayNames.test.js
@@ -1,0 +1,33 @@
+describe('Display names', () => {
+  before(() => {
+    cy.loadStory(['regression', 'all'], ['display-names'])
+  })
+
+  it('Box should have a meaningful display name', () => {
+    cy.get('#box').should('have.text', 'Box')
+  })
+
+  it('Composition should have meaningful display name', () => {
+    cy.get('#composition').should(
+      'have.attr',
+      'data-display-name',
+      'Composition',
+    )
+  })
+
+  it('Composition areas should have meaningful display name', () => {
+    cy.get('#composition-area').should('have.text', 'Area(One)')
+  })
+
+  it('Only should have meaningful display name', () => {
+    cy.get('#only').should('have.text', 'Only')
+  })
+
+  it('Visible should have meaningful display name', () => {
+    cy.get('#visible').should('have.text', 'Visible')
+  })
+
+  it('MediaQuery should have meaningful display name', () => {
+    cy.get('#media-query').should('have.text', 'MediaQuery')
+  })
+})

--- a/packages/atomic-layout-core/src/utils/templates/generateComponents/generateComponents.ts
+++ b/packages/atomic-layout-core/src/utils/templates/generateComponents/generateComponents.ts
@@ -36,7 +36,7 @@ export default function generateComponents(
 
     const Component = createAreaComponent(areaName)
     const capitalizedAreaName = capitalize(areaName)
-    Component.displayName = capitalizedAreaName
+    Component.displayName = `Area(${capitalizedAreaName})`
 
     const ResponsiveComponent = shouldAlwaysRender
       ? Component

--- a/packages/atomic-layout/src/components/Box.tsx
+++ b/packages/atomic-layout/src/components/Box.tsx
@@ -17,4 +17,6 @@ const Box: React.FC<BoxProps> = styled.div<BoxProps>`
   }
 `
 
+Box.displayName = 'Box'
+
 export default Box

--- a/packages/atomic-layout/src/components/Composition.tsx
+++ b/packages/atomic-layout/src/components/Composition.tsx
@@ -57,4 +57,6 @@ const Composition: React.FC<CompositionProps> = ({
   )
 }
 
+Composition.displayName = 'Composition'
+
 export default Composition

--- a/packages/atomic-layout/src/components/MediaQuery.tsx
+++ b/packages/atomic-layout/src/components/MediaQuery.tsx
@@ -17,6 +17,7 @@ const MediaQuery: React.FC<MediaQueryProps> = ({
   return children(matches)
 }
 
+MediaQuery.displayName = 'MediaQuery'
 MediaQuery.defaultProps = {
   matches: false,
 }

--- a/packages/atomic-layout/src/components/Only.tsx
+++ b/packages/atomic-layout/src/components/Only.tsx
@@ -106,4 +106,6 @@ const Only: React.FC<OnlyProps> = ({
   return <>children</>
 }
 
+Only.displayName = 'Only'
+
 export default Only

--- a/packages/atomic-layout/src/components/Visible.tsx
+++ b/packages/atomic-layout/src/components/Visible.tsx
@@ -74,4 +74,6 @@ const Visible: React.FC<OnlyProps> = ({
   )
 }
 
+Visible.displayName = 'Visible'
+
 export default Visible


### PR DESCRIPTION
## Changes

<!-- Describe the changes introduced by this Pull request -->

- The following exported components are being given a meaningful `displayName` property that mirror the respective component's name:

  - `Box`
  - `Composition`
  - `Visible`
  - `Only`
  - `MediaQuery`

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Closes #306

## Release version

<!-- Check the character of your changes -->

- [ ] internal (no release required)
- [x] patch (bug fixes)
- [ ] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [x] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [x] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->
