### PR TITLE
Parses prop names in case-sensitive manner

### DIFF
--- a/packages/atomic-layout-core/src/utils/strings/parsePropName/parsePropName.spec.ts
+++ b/packages/atomic-layout-core/src/utils/strings/parsePropName/parsePropName.spec.ts
@@ -60,6 +60,42 @@ describe('parsePropName', () => {
     })
   })
 
+  it('ignores valid breakpoint written in lowercase', () => {
+    expect(parsePropName('guttermd')).toEqual({
+      originPropName: 'guttermd',
+      purePropName: 'guttermd',
+      behavior: 'up',
+      breakpoint: {
+        name: 'xs',
+        isDefault: true,
+      },
+    })
+  })
+
+  it('ignores valid behavior written in lowercase', () => {
+    expect(parsePropName('gutterdown')).toEqual({
+      originPropName: 'gutterdown',
+      purePropName: 'gutterdown',
+      behavior: 'up',
+      breakpoint: {
+        name: 'xs',
+        isDefault: true,
+      },
+    })
+  })
+
+  it('ignores valid breakpoint and behavior written in lowercase', () => {
+    expect(parsePropName('gutterlgdown')).toEqual({
+      originPropName: 'gutterlgdown',
+      purePropName: 'gutterlgdown',
+      behavior: 'up',
+      breakpoint: {
+        name: 'xs',
+        isDefault: true,
+      },
+    })
+  })
+
   it('ignores unknown suffixes', () => {
     expect(parsePropName('gutterFoo')).toEqual({
       originPropName: 'gutterFoo',

--- a/packages/atomic-layout-core/src/utils/strings/parsePropName/parsePropName.ts
+++ b/packages/atomic-layout-core/src/utils/strings/parsePropName/parsePropName.ts
@@ -1,6 +1,7 @@
 import { BreakpointBehavior } from '../../../const/defaultOptions'
 import Layout from '../../../Layout'
 import toLowerCaseFirst from '../toLowerCaseFirst'
+import capitalize from '../capitalize'
 
 export interface Props {
   [propName: string]: any
@@ -27,10 +28,12 @@ export interface ParsedBreakpoint {
  * lookbehind is supported everywhere.
  */
 export default function parsePropName(originPropName: string): ParsedProp {
-  const joinedBreakpointNames = Object.keys(Layout.breakpoints).join('|')
-  const joinedBehaviors = ['down', 'only'].join('|')
-  const breakpointExp = new RegExp(`(${joinedBreakpointNames})$`, 'gi')
-  const behaviorExp = new RegExp(`(${joinedBehaviors})$`, 'gi')
+  const joinedBreakpointNames = Object.keys(Layout.breakpoints)
+    .map(capitalize)
+    .join('|')
+  const joinedBehaviors = ['down', 'only'].map(capitalize).join('|')
+  const breakpointExp = new RegExp(`(${joinedBreakpointNames})$`, 'g')
+  const behaviorExp = new RegExp(`(${joinedBehaviors})$`, 'g')
 
   const behaviorMatch = originPropName.match(behaviorExp)
   const behavior = behaviorMatch ? behaviorMatch[0] : ''


### PR DESCRIPTION
## Changes

<!-- Describe the changes introduced by this Pull request -->

- Removes the `i` regular expression flag from `parsePropName()`
- Adds unit tests to check that `parsePropName()` does not tolerate breakpoint and/or behavior written in lowercase

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Closes #296 

## Release version

<!-- Check the character of your changes -->

> Treating this as a minor change, because it introduces a behavior change that is not backward-compatible. Developers who had wrong responsive props declarations (and those still worked due to the previously case-insensitive parsing) will have their responsive broken with this change, and would have to rewrite responsive props to follow proper casing.

- [ ] internal (no release required)
- [ ] patch (bug fixes)
- [x] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [x] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [x] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->
