### PR TITLE
Memoizes areas generation in Composition

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -132,9 +132,11 @@ import DisplayNames from './regression/DisplayNames'
 import StylesUndefined from './regression/StylesUndefined'
 import SingleResponsiveProp from './regression/SingleResponsiveProp'
 import OnlyUnmount from './regression/OnlyUnmount'
+import ParentRerendering from './regression/ParentRerendering'
 
 storiesOf('Regression|All', module)
   .add('Display names', DisplayNames)
   .add('Styles undefined', StylesUndefined)
   .add('Single responsive prop', SingleResponsiveProp)
   .add('Only unmount', OnlyUnmount)
+  .add('Parent re-rendering', ParentRerendering)

--- a/examples/regression/DisplayNames.jsx
+++ b/examples/regression/DisplayNames.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Composition, Only, Visible, MediaQuery } from 'atomic-layout'
+import { Box, Composition, Only, Visible } from 'atomic-layout'
 
 const DisplayNames = () => (
   <div>
@@ -19,9 +19,6 @@ const DisplayNames = () => (
     <Visible id="visible" from="xs">
       {Visible.displayName}
     </Visible>
-    <MediaQuery matches={true}>
-      {() => <p id="media-query">{MediaQuery.displayName}</p>}
-    </MediaQuery>
   </div>
 )
 

--- a/examples/regression/DisplayNames.test.js
+++ b/examples/regression/DisplayNames.test.js
@@ -26,8 +26,4 @@ describe('Display names', () => {
   it('Visible should have meaningful display name', () => {
     cy.get('#visible').should('have.text', 'Visible')
   })
-
-  it('MediaQuery should have meaningful display name', () => {
-    cy.get('#media-query').should('have.text', 'MediaQuery')
-  })
 })

--- a/examples/regression/ParentRerendering.jsx
+++ b/examples/regression/ParentRerendering.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+import { Composition } from 'atomic-layout'
+
+const ParentRerendering = () => {
+  const [value, setValue] = useState('')
+
+  return (
+    <Composition areas="title content">
+      {(Areas) => (
+        <>
+          <Areas.Title>
+            <h2>Title</h2>
+          </Areas.Title>
+          <Areas.Content>
+            <input
+              name="username"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+            />
+          </Areas.Content>
+        </>
+      )}
+    </Composition>
+  )
+}
+
+export default ParentRerendering

--- a/examples/regression/ParentRerendering.test.js
+++ b/examples/regression/ParentRerendering.test.js
@@ -1,0 +1,12 @@
+describe('Parent re-rendering', () => {
+  before(() => {
+    cy.loadStory(['regression', 'all'], ['parent-re-rendering'])
+  })
+
+  it('Should preserve areas state when parent updates', () => {
+    cy.get('input[name="username"]')
+      .type('admin')
+      .should('be.focused')
+      .should('have.value', 'admin')
+  })
+})

--- a/packages/atomic-layout/src/components/Composition.tsx
+++ b/packages/atomic-layout/src/components/Composition.tsx
@@ -31,11 +31,13 @@ const Composition: React.FC<CompositionProps> = ({
   ...restProps
 }) => {
   const areasList = parseTemplates(restProps)
-  const Areas = generateComponents(
-    areasList,
-    createAreaComponent,
-    withPlaceholder,
-  )
+
+  // Memoize areas generation so parental updates do not re-generate areas,
+  // making area components preserve their internal state.
+  const Areas = React.useMemo(() => {
+    return generateComponents(areasList, createAreaComponent, withPlaceholder)
+  }, [areasList])
+
   const hasAreaComponents = Object.keys(Areas).length > 0
   const childrenType = typeof children
   const hasChildrenFunction = childrenType === 'function'


### PR DESCRIPTION
## Changes

<!-- Describe the changes introduced by this Pull request -->

- Wraps `generateComponents()` call in `Composition` in `useMemo` hook, so that generated area components do not lose their state whenever parent updates. Change of the value of `areas`/`template` prop would still trigger re-generation of components.
- Removes the assertion on `MediaQuery` from the E2E tests

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Fixes #320 

## Release version

<!-- Check the character of your changes -->

- [ ] internal (no release required)
- [x] patch (bug fixes)
- [ ] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [x] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [x] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->
