### PR TITLE
useResponsiveValue: Fires a side effect on dependency change

### DIFF
--- a/packages/atomic-layout/src/hooks/useResponsiveValue.ts
+++ b/packages/atomic-layout/src/hooks/useResponsiveValue.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { withBreakpoints } from '@atomic-layout/core'
 import useBreakpointChange from './useBreakpointChange'
 
@@ -13,10 +13,14 @@ const useResponsiveValue = <ValueType>(
 ): ValueType => {
   const [value, setValue] = useState<ValueType>(defaultValue)
 
-  useBreakpointChange(() => {
+  const callback = () => {
     const nextValue = withBreakpoints<ValueType>(breakpoints, defaultValue)
     setValue(nextValue)
-  })
+  }
+
+  useEffect(callback, [breakpoints, defaultValue])
+
+  useBreakpointChange(callback)
 
   return value
 }


### PR DESCRIPTION
The useResponsiveValue hook does not update the value if one of the dependencies changes.
Internationalisation is a good example for this situation.

## Changes

<!-- Describe the changes introduced by this Pull request -->

- Adds a side effect for hook `useResponsiveValue`

## Issues

<!-- Reference GitHub issues closed or related this this Pull request -->

- Closes #326 

## Release version

<!-- Check the character of your changes -->

- [ ] internal (no release required)
- [x] patch (bug fixes)
- [ ] minor (backward-compatible changes)
- [ ] major (backward-incompatible, breaking changes)

## Contributor's checklist

<!-- Make sure you've done all of the checks below -->

- [x] My branch is up-to-date with the latest `master`

<!--
$ git checkout master
$ git pull --rebase
$ git checkout MY_BRANCH
$ git rebase master
-->

- [x] I ran `yarn verify` to see the build and tests pass

<!--
$ yarn verify
-->
